### PR TITLE
15 Replace redundant seed data with times.do loops and Faker dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ script:
   - bundle exec rake db:create
   - bundle exec rake db:migrate
   - bundle exec rspec spec/models
+  - bundle exec rake db:seed

--- a/Gemfile
+++ b/Gemfile
@@ -48,11 +48,12 @@ group :development, :test do
   gem 'awesome_print'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'bullet' #detects N+1 queries via config/initializers/bullet.rb
+  gem 'bullet' # detects N+1 queries via config/initializers/bullet.rb
+  gem 'faker' # creates fake data for seeding
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'pry-awesome_print'
-  gem 'better_errors' #creates console in browser for errors
+  gem 'better_errors' # creates console in browser for errors
   gem 'binding_of_caller' #goes with better_errors
   gem 'lol_dba' # profiles app for performance
   gem 'rspec-rails', '~> 3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
+    faker (1.9.3)
+      i18n (>= 0.7)
     ffi (1.10.0)
     flay (2.12.0)
       erubis (~> 2.7.0)
@@ -379,6 +381,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   factory_bot_rails (~> 4.0)
+  faker
   groupdate
   guard-rspec
   jbuilder (~> 2.5)

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -28,12 +28,12 @@
 <h3>All Time -- Grouped by Day</h3>
 <%= area_chart [
   {name: "Qty Exercises", data: ExerciseLog.group_by_day(:datetime_occurred).count},
-  {name: "Pain Levels", data: PainLog.group_by_day(:datetime_occurred).sum(:pain_level)},
+  {name: "Pain Levels Total", data: PainLog.group_by_day(:datetime_occurred).sum(:pain_level)},
 ] %>
 
 <%= bar_chart [
   {name: "Minutes Exercised", data: ExerciseLog.minutes_spent_by_day},
-  {name: "Pain Levels", data: PainLog.group_by_day(:datetime_occurred).sum(:pain_level)},
+  {name: "Pain Levels Total", data: PainLog.group_by_day(:datetime_occurred).sum(:pain_level)},
 ] %>
 
 <hr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,54 +1,131 @@
 # frozen_string_literal: true
 
+#-------------------------------------------
+#             DELETE ALL SEEDS
+#-------------------------------------------
 puts 'Destroying all assets'
-  ExerciseLog.destroy_all
-  PainLog.destroy_all
-  PhysicalTherapySession.destroy_all
-  Pain.destroy_all
-  BodyPart.destroy_all
-  Exercise.destroy_all
-  User.destroy_all
+ExerciseLog.destroy_all
+PainLog.destroy_all
+PtSession.destroy_all
+Pain.destroy_all
+BodyPart.destroy_all
+Exercise.destroy_all
+User.destroy_all
 
+
+#-------------------------------------------
+#            BUILD BASE CLASSES
+#-------------------------------------------
 puts 'Building Users'
-  user = FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@example.com', admin: true)
+user = FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@example.com', admin: true)
 
+#------------------------------------------
 puts 'Building Exercises'
-  FactoryBot.create(:exercise, user_id: user.id, name: 'clam shells', description: 'lie on one side with legs bent at knees', default_per_side: true )
-  FactoryBot.create(:exercise, user_id: user.id, name: 'bridges', description: 'lie on back with legs bent at knees. lift butt up.' )
-  FactoryBot.create(:exercise, user_id: user.id, name: 'cross-body isometrics', description: 'lie on back with legs bent at knees. bring right knee towards chest but push back with left hand. hold and engage core. alternate sides.' )
-  FactoryBot.create(:exercise, user_id: user.id, name: 'wall slides', description: 'lie on side with body flat against wall. raise leg up, sliding heel againt wall.' )
+FactoryBot.create(:exercise, user_id: user.id, name: 'clam shells', description: 'lie on one side with legs bent at knees', default_per_side: true )
+FactoryBot.create(:exercise, user_id: user.id, name: 'wall slides', description: 'lie on side with body flat against wall. raise leg up, sliding heel againt wall.', default_per_side: true )
+FactoryBot.create(:exercise, user_id: user.id, name: 'bridges', description: 'lie on back with legs bent at knees. lift butt up.' )
+FactoryBot.create(:exercise, user_id: user.id, name: 'cross-body isometrics', description: 'lie on back with legs bent at knees. bring right knee towards chest but push back with left hand. hold and engage core. alternate sides.' )
 
+#------------------------------------------
 puts 'Building Body Parts'
-  FactoryBot.create(:body_part, user_id: user.id, name: 'hip, right')
-  FactoryBot.create(:body_part, user_id: user.id, name: 'hip, left')
-  FactoryBot.create(:body_part, user_id: user.id, name: 'knee, right')
-  FactoryBot.create(:body_part, user_id: user.id, name: 'knee, left')
-  body_part = BodyPart.first
+body_part_names = ['hip, right', 'hip, left', 'knee, right', 'knee, left']
 
+body_part_names.each do |body_part_name|
+  FactoryBot.create(:body_part, user_id: user.id, name: body_part_name)
+end
+
+body_part = BodyPart.first
+
+#------------------------------------------
 puts 'Building Pains'
-  FactoryBot.create(:pain, user_id: user.id, name: 'aching')
-  FactoryBot.create(:pain, user_id: user.id, name: 'burning')
-  FactoryBot.create(:pain, user_id: user.id, name: 'throbbing')
-  FactoryBot.create(:pain, user_id: user.id, name: 'stabbing')
-  FactoryBot.create(:pain, user_id: user.id, name: 'stiffness')
-  pain = Pain.all.sample
+pain_names = ['aching', 'burning', 'throbbing', 'stabbing', 'stiffness']
 
+pain_names.each do |pain_name|
+  FactoryBot.create(:pain, user_id: user.id, name: pain_name)
+end
+
+pain = Pain.all.sample
+
+
+#-------------------------------------------
+#              BUILD LOGS
+#-------------------------------------------
 puts 'Building Logs'
-  FactoryBot.create(:exercise_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, exercise_id: Exercise.all.sample.id, datetime_occurred: '2019-03-23 19:29:00', progress_note: 'generally feels more supported, but pain is still very present')
-  FactoryBot.create(:exercise_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, exercise_id: Exercise.all.sample.id, datetime_occurred: '2019-03-24 09:30:00', progress_note: 'feeling good this morning. hip cracked during exercise and that felt nice.')
-  FactoryBot.create(:exercise_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, exercise_id: Exercise.all.sample.id, datetime_occurred: '2019-03-21 15:30:00', progress_note: 'feels weaker than other side. Didn’t notice much of a difference after this session.')
-  FactoryBot.create(:exercise_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, exercise_id: Exercise.all.sample.id, datetime_occurred: '2019-03-21 18:00:00', progress_note: 'Went for a walk right afterwards. We did 1 little loop and i was not feeling much pain, so we did another small loop.')
-  FactoryBot.create(:exercise_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, exercise_id: Exercise.all.sample.id, datetime_occurred: '2019-03-22 06:30:00', progress_note: 'feels weaker than right also, hip is a little sore this morning in the joint. it doesn’t feel like workout sore.')
-  FactoryBot.create(:exercise_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, exercise_id: Exercise.all.sample.id, datetime_occurred: '2019-03-22 17:00:00', progress_note: 'still feels weaker than other side. weird. no muscle soreness from exercise.')
-  FactoryBot.create(:exercise_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, exercise_id: Exercise.all.sample.id, datetime_occurred: '2019-03-23 10:00:00', progress_note: 'feels weaker than other side also, hip is a little sore this morning in the joint.')
+LOG_MULTIPLIER = 30
 
-  FactoryBot.create(:pain_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, pain_id: Pain.all.sample.id, datetime_occurred: '2019-03-23 10:45:00')
-  FactoryBot.create(:pain_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, pain_id: Pain.all.sample.id, datetime_occurred: '2019-03-24 02:00:00')
-  FactoryBot.create(:pain_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, pain_id: Pain.all.sample.id, datetime_occurred: '2019-03-25 06:15:00')
-  FactoryBot.create(:pain_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, pain_id: Pain.all.sample.id, datetime_occurred: '2019-03-26 07:00:00')
-  FactoryBot.create(:pain_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, pain_id: Pain.all.sample.id, datetime_occurred: '2019-03-27 10:00:00')
-  FactoryBot.create(:pain_log, user_id: user.id, body_part_id: BodyPart.all.sample.id, pain_id: Pain.all.sample.id, datetime_occurred: '2019-03-28 10:30:00')
+def generate_datetime
+  h = rand(6..20)
+  Faker::Date.between(1.month.ago, Date.today).to_datetime + h.hours
+end
 
-  FactoryBot.create(:pt_session, user_id: user.id, body_part_id: BodyPart.all.sample.id, datetime_occurred: '2019-03-24 08:40:00', exercise_notes: 'clamshells + yellow band: 3 sets 10 reps each side, cross body isometrics: 5 second push, 10 reps each leg', homework: 'same as session')
-  FactoryBot.create(:pt_session, user_id: user.id, body_part_id: BodyPart.all.sample.id, datetime_occurred: '2019-03-26 05:30:00', exercise_notes: 'bridges: 3 sets 10 reps, 10 second hold, strap stretch hams: 1 set 10 reps each leg. lift leg straight up with strap and hold for 10 sec', homework: 'same as session')
-  FactoryBot.create(:pt_session, user_id: user.id, body_part_id: BodyPart.all.sample.id, datetime_occurred: '2019-03-28 04:30:00', exercise_notes: 'strap stretch quad: 10 set 10 reps hold for 10 seconds, crouch walk with band: 2 laps, squats on machine: 2 sets 10 reps', homework: 'same as session')
+#------------------------------------------
+puts '... Exercise Logs'
+  progress_notes = [
+    'generally feels more supported, but pain is still very present',
+    'feeling good this morning. hip cracked during exercise and that felt nice.',
+    'feels weaker than other side. Didn’t notice much of a difference after this session.',
+    'Went for a walk right afterwards. We did 1 little loop and i was not feeling much pain, so we did another small loop.',
+    'feels weaker than right also, hip is a little sore this morning in the joint. it doesn’t feel like workout sore.',
+    'still feels weaker than other side. weird. no muscle soreness from exercise.',
+    'feels weaker than other side also is a little sore this morning in the joint.'
+  ]
+
+  LOG_MULTIPLIER.times do
+    FactoryBot.create(
+      :exercise_log,
+      user_id: user.id,
+      body_part_id: BodyPart.all.sample.id,
+      exercise_id: Exercise.all.sample.id,
+      datetime_occurred: generate_datetime,
+      progress_note: progress_notes.sample
+    )
+  end
+
+  #------------------------------------------
+  puts '... Pain Logs'
+  LOG_MULTIPLIER.times do
+    FactoryBot.create(
+      :pain_log,
+      user_id: user.id,
+      body_part_id: BodyPart.all.sample.id,
+      pain_id: Pain.all.sample.id,
+      datetime_occurred: generate_datetime
+    )
+  end
+
+  #------------------------------------------
+  puts '... Physical Therapy Session Logs'
+  exercise_note_opts = [
+    'clamshells + yellow band: 3 sets 10 reps each side, cross body isometrics: 5 second push, 10 reps each leg',
+    'bridges: 3 sets 10 reps, 10 second hold, strap stretch hams: 1 set 10 reps each leg. lift leg straight up with strap and hold for 10 sec',
+    'strap stretch quad: 10 set 10 reps hold for 10 seconds, crouch walk with band: 2 laps, squats on machine: 2 sets 10 reps',
+  ]
+
+  homework_notes = [
+    'same as session',
+    'do regular exercises and incorporate in 1 or two extra sets or reps where you can',
+    'regular exercises plus add in an extra walk around the neighborhood',
+    'regular exercises plus add in an extra bike ride',
+    'try walking as fast as you can to see how far you can get before pain sets in'
+  ]
+
+  LOG_MULTIPLIER.times do
+    log = FactoryBot.create(
+      :pt_session,
+      user_id: user.id,
+      body_part_id: BodyPart.all.sample.id,
+      datetime_occurred: generate_datetime,
+      exercise_notes: exercise_note_opts.sample,
+      homework: homework_notes.sample
+    )
+
+    exercise_multiplier = (1..(Exercise.count)).to_a.sample
+
+    exercise_multiplier.times do
+      log.homework_exercises << Exercise.all.sample
+    end
+
+    exercise_multiplier.times do
+      log.session_exercises << Exercise.all.sample
+    end
+  end

--- a/spec/factories/exercise_log.rb
+++ b/spec/factories/exercise_log.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     rep_length { 5 }
     burn_set { 2 }
     burn_rep { 5 }
+    resistance { ['', 'yellow band', 'green band'].sample }
     progress_note { 'progress note body' }
   end
 end

--- a/spec/factories/exercises.rb
+++ b/spec/factories/exercises.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     default_reps { 10 }
     default_rep_length { 5 }
     default_per_side { false }
+    default_resistance { ['', 'yellow band', 'green band'].sample }
   end
 
   trait :with_3_exercise_logs do


### PR DESCRIPTION
Closes #15 

## Problem
The seeds files was getting out of date as compared to the models. For example, I've added new fields and also done a couple of name changes. The seeds file was falling behind because it had to be updated manually. Also, color me lazy, but it was getting tedious to come up with realistic-looking timeframes for each of the logs. 

## Solution
I moved as much logic as I could into factories. Since factories need to be updated in order to keep tests up to date, this is an automatic win for  updating the seeds as a byproduct. Adding in `Faker`'s `Date` module give us access to a lovely assortment of dates for when logs occur. I foresee this setup being much more scalable and easier to maintain. 