### PR TITLE
Add stats to pt session exercises

### DIFF
--- a/app/controllers/pt_sessions_controller.rb
+++ b/app/controllers/pt_sessions_controller.rb
@@ -14,9 +14,11 @@ class PtSessionsController < ApplicationController
 
   def new
     @pt_session = current_user.pt_sessions.new
+    10.times { @pt_session.pt_session_exercises.build }
   end
 
   def edit
+    5.times { @pt_session.pt_session_exercises.build }
   end
 
   def create
@@ -59,7 +61,20 @@ class PtSessionsController < ApplicationController
     end
 
     def pt_session_params
-      params.require(:pt_session).permit(:user_id, :body_part_id, :datetime_occurred, :exercise_notes, :homework, :duration, session_exercise_ids: [], homework_exercise_ids: [])
+      params.require(:pt_session).permit(:user_id,
+                                         :body_part_id,
+                                         :datetime_occurred,
+                                         :exercise_notes,
+                                         :homework, :duration,
+                                         homework_exercise_ids: [],
+                                         pt_session_exercises_attributes: %i[
+                                           id
+                                           exercise_id
+                                           sets
+                                           reps
+                                           resistance
+                                           _destroy
+                                         ])
     end
 
     def authorize_pt_session

--- a/app/helpers/pt_sessions_helper.rb
+++ b/app/helpers/pt_sessions_helper.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 module PtSessionsHelper
+  def display_exercise_stats(exercise)
+    output = "#{exercise.exercise_name}"
+    output += ": #{exercise.sets} sets of #{exercise.reps} reps" unless exercise.blank_stats?
+    output += " with #{exercise.resistance}" unless exercise.resistance.blank?
+    output
+  end
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -9,7 +9,6 @@ class Exercise < ApplicationRecord
   has_many :pt_homework_sessions, through: :pt_homework_exercises, source: :pt_session
 
   has_many :pt_session_exercises, dependent: :destroy  # the join table
-  has_many :pt_exercise_sessions, through: :pt_session_exercises, source: :pt_session
 
   validates :description,
             :default_sets,

--- a/app/models/pain_log.rb
+++ b/app/models/pain_log.rb
@@ -16,8 +16,8 @@ class PainLog < ApplicationRecord
             presence: true,
             numericality: true
 
-  delegate :name, to: :pain, prefix: true
   delegate :name, to: :body_part, prefix: true
+  delegate :name, to: :pain, prefix: true
 
   def self.past_two_weeks
     where('datetime_occurred >= ? AND datetime_occurred <= ?', (Date.today.to_datetime - 14.days), Date.today.to_datetime)

--- a/app/models/pt_session.rb
+++ b/app/models/pt_session.rb
@@ -4,11 +4,14 @@ class PtSession < ApplicationRecord
   belongs_to :user
   belongs_to :body_part
 
+  has_many :pt_session_exercises, inverse_of: :pt_session, dependent: :destroy
+  accepts_nested_attributes_for :pt_session_exercises,
+                                reject_if: :all_blank, # at least 1 exercise should be present
+                                allow_destroy: true # allows user to delete exercise via checkbox
+
   has_many :pt_homework_exercises, dependent: :destroy
   has_many :homework_exercises, through: :pt_homework_exercises, source: :exercise
 
-  has_many :pt_session_exercises, dependent: :destroy
-  has_many :session_exercises, through: :pt_session_exercises, source: :exercise
 
   validates :datetime_occurred,
             :body_part_id,

--- a/app/models/pt_session_exercise.rb
+++ b/app/models/pt_session_exercise.rb
@@ -1,6 +1,12 @@
 class PtSessionExercise < ApplicationRecord
-  belongs_to :pt_session
+  belongs_to :pt_session, inverse_of: :pt_session_exercises
   belongs_to :exercise
 
   validates :pt_session, :exercise, presence: true
+
+  delegate :name, to: :exercise, prefix: true
+
+  def blank_stats?
+    sets.blank? || reps.blank?
+  end
 end

--- a/app/views/pt_sessions/_form.html.erb
+++ b/app/views/pt_sessions/_form.html.erb
@@ -24,18 +24,41 @@
     <%= form.text_area :exercise_notes, class: 'form-control textarea-large' %>
   </div>
 
-  <div class="form-group row">
-    <div class="col-sm-12">
-    <%= form.label 'Session Exercises' %>
+  <%= form.label 'Session Exercises' %>
+  <div class="row">
+    <div class="col"><%= form.label :exercise %></div>
+    <div class="col"><%= form.label :sets %></div>
+    <div class="col"><%= form.label :reps %></div>
+    <div class="col"><%= form.label :resistance %></div>
+    <div class="col"><%= form.label 'Delete?' %></div>
+  </div> <!-- row -->
 
-    <%= form.collection_check_boxes :session_exercise_ids, current_user.exercises.by_name, :id, :name do |exercise| %>
-      <div class='form-check'>
-        <%= exercise.check_box class: 'form-check-input' %>
-        <%= exercise.label class: 'form-check-label' %>
+  <%= form.fields_for :pt_session_exercises do |f_session_exercise| %>
+    <div class="row mb-2">
+      <div class="col">
+        <%= f_session_exercise.collection_select :exercise_id,
+          current_user.exercises.by_name, :id, :name,
+          { include_blank: true },
+          class: 'form-control' %>
       </div>
-    <% end %>
-    </div>
-  </div>
+
+      <div class="col">
+        <%= f_session_exercise.number_field :sets, class: 'form-control' %>
+      </div>
+
+      <div class="col">
+        <%= f_session_exercise.number_field :reps, class: 'form-control' %>
+      </div>
+
+      <div class="col">
+        <%= f_session_exercise.text_field :resistance, class: 'form-control' %>
+      </div>
+
+      <div class="col">
+        <%= f_session_exercise.check_box :_destroy %>
+      </div>
+    </div> <!-- row -->
+  <% end %><!-- session exercise form -->
 
   <div class="field">
     <%= form.label :homework %>

--- a/app/views/pt_sessions/show.html.erb
+++ b/app/views/pt_sessions/show.html.erb
@@ -4,8 +4,8 @@
 <h5>Session Notes</h5>
 <p><%= @pt_session.exercise_notes %></p>
 <ul>
-  <% @pt_session.session_exercises.each do |exercise| %>
-    <li><%= exercise.name %></li>
+  <% @pt_session.pt_session_exercises.each do |session_exercise| %>
+    <li><%= display_exercise_stats(session_exercise) %></li>
   <% end %>
 </ul>
 

--- a/db/migrate/20190426010827_add_stats_to_pt_session_exercises.rb
+++ b/db/migrate/20190426010827_add_stats_to_pt_session_exercises.rb
@@ -1,0 +1,7 @@
+class AddStatsToPtSessionExercises < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pt_session_exercises, :sets, :integer
+    add_column :pt_session_exercises, :reps, :integer
+    add_column :pt_session_exercises, :resistance, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_23_005755) do
+ActiveRecord::Schema.define(version: 2019_04_26_010827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,9 @@ ActiveRecord::Schema.define(version: 2019_04_23_005755) do
     t.bigint "exercise_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sets"
+    t.integer "reps"
+    t.string "resistance"
     t.index ["exercise_id"], name: "index_pt_session_exercises_on_exercise_id"
     t.index ["pt_session_id"], name: "index_pt_session_exercises_on_pt_session_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -126,6 +126,6 @@ puts '... Exercise Logs'
     end
 
     exercise_multiplier.times do
-      log.session_exercises << Exercise.all.sample
+      FactoryBot.create(:pt_session_exercise, pt_session_id: log.id, exercise_id: Exercise.all.sample.id)
     end
   end

--- a/spec/factories/pain_logs.rb
+++ b/spec/factories/pain_logs.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     body_part
     pain
     datetime_occurred { '2019-03-25 20:15:37' }
-    pain_level { (1..5).to_a.sample }
+    pain_level { rand(1..5) }
     pain_description { 'sample pain description' }
     trigger { 'sample pain trigger' }
   end

--- a/spec/factories/pt_session_exercises.rb
+++ b/spec/factories/pt_session_exercises.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
   factory :pt_session_exercise do
     pt_session { nil }
-    exercise { nil }
+    exercise_id { nil }
+    sets { rand(1..4) }
+    reps { rand(5..15) }
+    resistance { ['', 'yellow band', 'green band'].sample }
   end
 end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Exercise, type: :model do
     it { should have_many(:pt_homework_exercises) }  # the join table
     it { should have_many(:pt_homework_sessions).through(:pt_homework_exercises) }
     it { should have_many(:pt_session_exercises) } # the join table
-    it { should have_many(:pt_exercise_sessions).through(:pt_session_exercises) }
   end
 
   context "validations" do

--- a/spec/models/pain_log_spec.rb
+++ b/spec/models/pain_log_spec.rb
@@ -20,9 +20,13 @@ RSpec.describe PainLog, type: :model do
     it { should validate_numericality_of(:pain_level) }
   end
 
+  context "delegations" do
+    it { should delegate_method(:name).to(:body_part).with_prefix }
+    it { should delegate_method(:name).to(:pain).with_prefix }
+  end
+
   describe 'self.past_two_weeks' do
     xit 'returns only the logs between today and the past 14 days' do
-
     end
   end
 

--- a/spec/models/pt_session_exercise_spec.rb
+++ b/spec/models/pt_session_exercise_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe PtSessionExercise, type: :model do
     it { should validate_presence_of(:pt_session) }
     it { should validate_presence_of(:exercise) }
   end
+
+  context "delegations" do
+    it { should delegate_method(:name).to(:exercise).with_prefix }
+  end
 end

--- a/spec/models/pt_session_spec.rb
+++ b/spec/models/pt_session_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe PtSession, type: :model do
     it { should have_many(:pt_homework_exercises) }
     it { should have_many(:homework_exercises).through(:pt_homework_exercises) }
     it { should have_many(:pt_session_exercises) }
-    it { should have_many(:session_exercises).through(:pt_session_exercises) }
   end
 
   context "validations" do
@@ -20,5 +19,22 @@ RSpec.describe PtSession, type: :model do
     it { should validate_presence_of(:duration) }
 
     it { should validate_numericality_of(:duration) }
+  end
+
+  describe '#blank_stats?' do
+    it 'returns true if sets are blank' do
+      pt_session_exercise = build(:pt_session_exercise, sets: nil)
+      expect(pt_session_exercise.blank_stats?).to be true
+    end
+
+    it 'returns true if reps are blank' do
+      pt_session_exercise = build(:pt_session_exercise, reps: nil)
+      expect(pt_session_exercise.blank_stats?).to be true
+    end
+
+    it 'returns false if there are both sets and reps' do
+      pt_session_exercise = build(:pt_session_exercise, sets: 1, reps: 1)
+      expect(pt_session_exercise.blank_stats?).to be false
+    end
   end
 end


### PR DESCRIPTION
## Problem
Previously, we could only add a simple exercise name to a physical therapy log in order to indicate the exercises done in that session. Like so:
<img width="911" alt="Screenshot 2019-04-25 20 57 35" src="https://user-images.githubusercontent.com/8680712/56778656-00a74780-679d-11e9-8aa3-916732a9d182.png">

## Solution
That's handy, but I wanted to track the progress of these exercises at each session. In order to do that, i needed to track more stats. I added details to the `pt_session_exercises` model in order to capture that information, like so:
<img width="1091" alt="Screenshot 2019-04-25 20 58 08" src="https://user-images.githubusercontent.com/8680712/56778688-30eee600-679d-11e9-832e-d58db4fcfbf1.png">

## Work Done
This work involved a migration to add new fields and also changing up the associations a little bit. There is what looks like more redundancy in some of the exercise stat display helpers and some tables, but i think it's still fine at this point. If we expand more, we may want to look into polymorphism to consolidate exercise data.


@kelseyhuse30, want to review this PR?