### PR TITLE
get controller tests passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ script:
   - bundle exec rake db:create
   - bundle exec rake db:migrate
   - bundle exec rspec spec/models
+  - bundle exec rspec spec/controllers
   - bundle exec rake db:seed

--- a/spec/controllers/body_parts_controller_spec.rb
+++ b/spec/controllers/body_parts_controller_spec.rb
@@ -26,27 +26,28 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 RSpec.describe BodyPartsController, type: :controller do
-
+  login_user
   # This should return the minimal set of attributes required to create a valid
   # BodyPart. As you add validations to BodyPart, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) {
-    skip("Add a hash of attributes valid for your model")
+    {
+      :name => "elbow",
+      :user_id => subject.current_user.id
+    }
   }
 
   let(:invalid_attributes) {
-    skip("Add a hash of attributes invalid for your model")
+    {
+      :name => "",
+      :user_id => subject.current_user.id
+    }
   }
-
-  # This should return the minimal set of values that should be in the session
-  # in order to pass any filters (e.g. authentication) defined in
-  # BodyPartsController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
 
   describe "GET #index" do
     it "returns a success response" do
       BodyPart.create! valid_attributes
-      get :index, params: {}, session: valid_session
+      get :index, params: {}
       expect(response).to be_successful
     end
   end
@@ -54,14 +55,14 @@ RSpec.describe BodyPartsController, type: :controller do
   describe "GET #show" do
     it "returns a success response" do
       body_part = BodyPart.create! valid_attributes
-      get :show, params: {id: body_part.to_param}, session: valid_session
+      get :show, params: {id: body_part.to_param}
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns a success response" do
-      get :new, params: {}, session: valid_session
+      get :new, params: {}
       expect(response).to be_successful
     end
   end
@@ -69,7 +70,7 @@ RSpec.describe BodyPartsController, type: :controller do
   describe "GET #edit" do
     it "returns a success response" do
       body_part = BodyPart.create! valid_attributes
-      get :edit, params: {id: body_part.to_param}, session: valid_session
+      get :edit, params: {id: body_part.to_param}
       expect(response).to be_successful
     end
   end
@@ -78,19 +79,19 @@ RSpec.describe BodyPartsController, type: :controller do
     context "with valid params" do
       it "creates a new BodyPart" do
         expect {
-          post :create, params: {body_part: valid_attributes}, session: valid_session
+          post :create, params: {body_part: valid_attributes}
         }.to change(BodyPart, :count).by(1)
       end
 
-      it "redirects to the created body_part" do
-        post :create, params: {body_part: valid_attributes}, session: valid_session
-        expect(response).to redirect_to(BodyPart.last)
+      it "redirects to the body parts index" do
+        post :create, params: {body_part: valid_attributes}
+        expect(response).to redirect_to(BodyPart)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: {body_part: invalid_attributes}, session: valid_session
+        post :create, params: {body_part: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -99,27 +100,27 @@ RSpec.describe BodyPartsController, type: :controller do
   describe "PUT #update" do
     context "with valid params" do
       let(:new_attributes) {
-        skip("Add a hash of attributes valid for your model")
+        { :name => "left elbow"}
       }
 
       it "updates the requested body_part" do
         body_part = BodyPart.create! valid_attributes
-        put :update, params: {id: body_part.to_param, body_part: new_attributes}, session: valid_session
+        put :update, params: {id: body_part.to_param, body_part: new_attributes}
         body_part.reload
-        skip("Add assertions for updated state")
+        body_part.name == new_attributes[:name]
       end
 
-      it "redirects to the body_part" do
+      it "redirects to the body_part index" do
         body_part = BodyPart.create! valid_attributes
-        put :update, params: {id: body_part.to_param, body_part: valid_attributes}, session: valid_session
-        expect(response).to redirect_to(body_part)
+        put :update, params: {id: body_part.to_param, body_part: valid_attributes}
+        expect(response).to redirect_to(BodyPart)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         body_part = BodyPart.create! valid_attributes
-        put :update, params: {id: body_part.to_param, body_part: invalid_attributes}, session: valid_session
+        put :update, params: {id: body_part.to_param, body_part: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -129,13 +130,13 @@ RSpec.describe BodyPartsController, type: :controller do
     it "destroys the requested body_part" do
       body_part = BodyPart.create! valid_attributes
       expect {
-        delete :destroy, params: {id: body_part.to_param}, session: valid_session
+        delete :destroy, params: {id: body_part.to_param}
       }.to change(BodyPart, :count).by(-1)
     end
 
     it "redirects to the body_parts list" do
       body_part = BodyPart.create! valid_attributes
-      delete :destroy, params: {id: body_part.to_param}, session: valid_session
+      delete :destroy, params: {id: body_part.to_param}
       expect(response).to redirect_to(body_parts_url)
     end
   end

--- a/spec/controllers/exercise_logs_controller_spec.rb
+++ b/spec/controllers/exercise_logs_controller_spec.rb
@@ -26,7 +26,7 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 RSpec.describe ExerciseLogsController, type: :controller do
-
+  login_user
   # This should return the minimal set of attributes required to create a valid
   # ExerciseLog. As you add validations to ExerciseLog, be sure to
   # adjust the attributes here as well.
@@ -38,15 +38,10 @@ RSpec.describe ExerciseLogsController, type: :controller do
     skip("Add a hash of attributes invalid for your model")
   }
 
-  # This should return the minimal set of values that should be in the session
-  # in order to pass any filters (e.g. authentication) defined in
-  # ExerciseLogsController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
-
   describe "GET #index" do
     it "returns a success response" do
       ExerciseLog.create! valid_attributes
-      get :index, params: {}, session: valid_session
+      get :index, params: {}
       expect(response).to be_successful
     end
   end
@@ -54,14 +49,14 @@ RSpec.describe ExerciseLogsController, type: :controller do
   describe "GET #show" do
     it "returns a success response" do
       exercise_log = ExerciseLog.create! valid_attributes
-      get :show, params: {id: exercise_log.to_param}, session: valid_session
+      get :show, params: {id: exercise_log.to_param}
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns a success response" do
-      get :new, params: {}, session: valid_session
+      get :new, params: {}
       expect(response).to be_successful
     end
   end
@@ -69,7 +64,7 @@ RSpec.describe ExerciseLogsController, type: :controller do
   describe "GET #edit" do
     it "returns a success response" do
       exercise_log = ExerciseLog.create! valid_attributes
-      get :edit, params: {id: exercise_log.to_param}, session: valid_session
+      get :edit, params: {id: exercise_log.to_param}
       expect(response).to be_successful
     end
   end
@@ -78,19 +73,19 @@ RSpec.describe ExerciseLogsController, type: :controller do
     context "with valid params" do
       it "creates a new ExerciseLog" do
         expect {
-          post :create, params: {exercise_log: valid_attributes}, session: valid_session
+          post :create, params: {exercise_log: valid_attributes}
         }.to change(ExerciseLog, :count).by(1)
       end
 
       it "redirects to the created exercise_log" do
-        post :create, params: {exercise_log: valid_attributes}, session: valid_session
+        post :create, params: {exercise_log: valid_attributes}
         expect(response).to redirect_to(ExerciseLog.last)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: {exercise_log: invalid_attributes}, session: valid_session
+        post :create, params: {exercise_log: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -104,14 +99,14 @@ RSpec.describe ExerciseLogsController, type: :controller do
 
       it "updates the requested exercise_log" do
         exercise_log = ExerciseLog.create! valid_attributes
-        put :update, params: {id: exercise_log.to_param, exercise_log: new_attributes}, session: valid_session
+        put :update, params: {id: exercise_log.to_param, exercise_log: new_attributes}
         exercise_log.reload
         skip("Add assertions for updated state")
       end
 
       it "redirects to the exercise_log" do
         exercise_log = ExerciseLog.create! valid_attributes
-        put :update, params: {id: exercise_log.to_param, exercise_log: valid_attributes}, session: valid_session
+        put :update, params: {id: exercise_log.to_param, exercise_log: valid_attributes}
         expect(response).to redirect_to(exercise_log)
       end
     end
@@ -119,7 +114,7 @@ RSpec.describe ExerciseLogsController, type: :controller do
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         exercise_log = ExerciseLog.create! valid_attributes
-        put :update, params: {id: exercise_log.to_param, exercise_log: invalid_attributes}, session: valid_session
+        put :update, params: {id: exercise_log.to_param, exercise_log: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -129,13 +124,13 @@ RSpec.describe ExerciseLogsController, type: :controller do
     it "destroys the requested exercise_log" do
       exercise_log = ExerciseLog.create! valid_attributes
       expect {
-        delete :destroy, params: {id: exercise_log.to_param}, session: valid_session
+        delete :destroy, params: {id: exercise_log.to_param}
       }.to change(ExerciseLog, :count).by(-1)
     end
 
     it "redirects to the exercise_logs list" do
       exercise_log = ExerciseLog.create! valid_attributes
-      delete :destroy, params: {id: exercise_log.to_param}, session: valid_session
+      delete :destroy, params: {id: exercise_log.to_param}
       expect(response).to redirect_to(exercise_logs_url)
     end
   end

--- a/spec/controllers/exercises_controller_spec.rb
+++ b/spec/controllers/exercises_controller_spec.rb
@@ -26,7 +26,7 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 RSpec.describe ExercisesController, type: :controller do
-
+  login_user
   # This should return the minimal set of attributes required to create a valid
   # Exercise. As you add validations to Exercise, be sure to
   # adjust the attributes here as well.
@@ -38,15 +38,10 @@ RSpec.describe ExercisesController, type: :controller do
     skip("Add a hash of attributes invalid for your model")
   }
 
-  # This should return the minimal set of values that should be in the session
-  # in order to pass any filters (e.g. authentication) defined in
-  # ExercisesController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
-
   describe "GET #index" do
     it "returns a success response" do
       Exercise.create! valid_attributes
-      get :index, params: {}, session: valid_session
+      get :index, params: {}
       expect(response).to be_successful
     end
   end
@@ -54,14 +49,14 @@ RSpec.describe ExercisesController, type: :controller do
   describe "GET #show" do
     it "returns a success response" do
       exercise = Exercise.create! valid_attributes
-      get :show, params: {id: exercise.to_param}, session: valid_session
+      get :show, params: {id: exercise.to_param}
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns a success response" do
-      get :new, params: {}, session: valid_session
+      get :new, params: {}
       expect(response).to be_successful
     end
   end
@@ -69,7 +64,7 @@ RSpec.describe ExercisesController, type: :controller do
   describe "GET #edit" do
     it "returns a success response" do
       exercise = Exercise.create! valid_attributes
-      get :edit, params: {id: exercise.to_param}, session: valid_session
+      get :edit, params: {id: exercise.to_param}
       expect(response).to be_successful
     end
   end
@@ -78,19 +73,19 @@ RSpec.describe ExercisesController, type: :controller do
     context "with valid params" do
       it "creates a new Exercise" do
         expect {
-          post :create, params: {exercise: valid_attributes}, session: valid_session
+          post :create, params: {exercise: valid_attributes}
         }.to change(Exercise, :count).by(1)
       end
 
       it "redirects to the created exercise" do
-        post :create, params: {exercise: valid_attributes}, session: valid_session
+        post :create, params: {exercise: valid_attributes}
         expect(response).to redirect_to(Exercise.last)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: {exercise: invalid_attributes}, session: valid_session
+        post :create, params: {exercise: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -104,14 +99,14 @@ RSpec.describe ExercisesController, type: :controller do
 
       it "updates the requested exercise" do
         exercise = Exercise.create! valid_attributes
-        put :update, params: {id: exercise.to_param, exercise: new_attributes}, session: valid_session
+        put :update, params: {id: exercise.to_param, exercise: new_attributes}
         exercise.reload
         skip("Add assertions for updated state")
       end
 
       it "redirects to the exercise" do
         exercise = Exercise.create! valid_attributes
-        put :update, params: {id: exercise.to_param, exercise: valid_attributes}, session: valid_session
+        put :update, params: {id: exercise.to_param, exercise: valid_attributes}
         expect(response).to redirect_to(exercise)
       end
     end
@@ -119,7 +114,7 @@ RSpec.describe ExercisesController, type: :controller do
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         exercise = Exercise.create! valid_attributes
-        put :update, params: {id: exercise.to_param, exercise: invalid_attributes}, session: valid_session
+        put :update, params: {id: exercise.to_param, exercise: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -129,13 +124,13 @@ RSpec.describe ExercisesController, type: :controller do
     it "destroys the requested exercise" do
       exercise = Exercise.create! valid_attributes
       expect {
-        delete :destroy, params: {id: exercise.to_param}, session: valid_session
+        delete :destroy, params: {id: exercise.to_param}
       }.to change(Exercise, :count).by(-1)
     end
 
     it "redirects to the exercises list" do
       exercise = Exercise.create! valid_attributes
-      delete :destroy, params: {id: exercise.to_param}, session: valid_session
+      delete :destroy, params: {id: exercise.to_param}
       expect(response).to redirect_to(exercises_url)
     end
   end

--- a/spec/controllers/pain_logs_controller_spec.rb
+++ b/spec/controllers/pain_logs_controller_spec.rb
@@ -26,7 +26,7 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 RSpec.describe PainLogsController, type: :controller do
-
+  login_user
   # This should return the minimal set of attributes required to create a valid
   # PainLog. As you add validations to PainLog, be sure to
   # adjust the attributes here as well.
@@ -38,15 +38,10 @@ RSpec.describe PainLogsController, type: :controller do
     skip("Add a hash of attributes invalid for your model")
   }
 
-  # This should return the minimal set of values that should be in the session
-  # in order to pass any filters (e.g. authentication) defined in
-  # PainLogsController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
-
   describe "GET #index" do
     it "returns a success response" do
       PainLog.create! valid_attributes
-      get :index, params: {}, session: valid_session
+      get :index, params: {}
       expect(response).to be_successful
     end
   end
@@ -54,14 +49,14 @@ RSpec.describe PainLogsController, type: :controller do
   describe "GET #show" do
     it "returns a success response" do
       pain_log = PainLog.create! valid_attributes
-      get :show, params: {id: pain_log.to_param}, session: valid_session
+      get :show, params: {id: pain_log.to_param}
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns a success response" do
-      get :new, params: {}, session: valid_session
+      get :new, params: {}
       expect(response).to be_successful
     end
   end
@@ -69,7 +64,7 @@ RSpec.describe PainLogsController, type: :controller do
   describe "GET #edit" do
     it "returns a success response" do
       pain_log = PainLog.create! valid_attributes
-      get :edit, params: {id: pain_log.to_param}, session: valid_session
+      get :edit, params: {id: pain_log.to_param}
       expect(response).to be_successful
     end
   end
@@ -78,19 +73,19 @@ RSpec.describe PainLogsController, type: :controller do
     context "with valid params" do
       it "creates a new PainLog" do
         expect {
-          post :create, params: {pain_log: valid_attributes}, session: valid_session
+          post :create, params: {pain_log: valid_attributes}
         }.to change(PainLog, :count).by(1)
       end
 
       it "redirects to the created pain_log" do
-        post :create, params: {pain_log: valid_attributes}, session: valid_session
+        post :create, params: {pain_log: valid_attributes}
         expect(response).to redirect_to(PainLog.last)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: {pain_log: invalid_attributes}, session: valid_session
+        post :create, params: {pain_log: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -104,14 +99,14 @@ RSpec.describe PainLogsController, type: :controller do
 
       it "updates the requested pain_log" do
         pain_log = PainLog.create! valid_attributes
-        put :update, params: {id: pain_log.to_param, pain_log: new_attributes}, session: valid_session
+        put :update, params: {id: pain_log.to_param, pain_log: new_attributes}
         pain_log.reload
         skip("Add assertions for updated state")
       end
 
       it "redirects to the pain_log" do
         pain_log = PainLog.create! valid_attributes
-        put :update, params: {id: pain_log.to_param, pain_log: valid_attributes}, session: valid_session
+        put :update, params: {id: pain_log.to_param, pain_log: valid_attributes}
         expect(response).to redirect_to(pain_log)
       end
     end
@@ -119,7 +114,7 @@ RSpec.describe PainLogsController, type: :controller do
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         pain_log = PainLog.create! valid_attributes
-        put :update, params: {id: pain_log.to_param, pain_log: invalid_attributes}, session: valid_session
+        put :update, params: {id: pain_log.to_param, pain_log: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -129,13 +124,13 @@ RSpec.describe PainLogsController, type: :controller do
     it "destroys the requested pain_log" do
       pain_log = PainLog.create! valid_attributes
       expect {
-        delete :destroy, params: {id: pain_log.to_param}, session: valid_session
+        delete :destroy, params: {id: pain_log.to_param}
       }.to change(PainLog, :count).by(-1)
     end
 
     it "redirects to the pain_logs list" do
       pain_log = PainLog.create! valid_attributes
-      delete :destroy, params: {id: pain_log.to_param}, session: valid_session
+      delete :destroy, params: {id: pain_log.to_param}
       expect(response).to redirect_to(pain_logs_url)
     end
   end

--- a/spec/controllers/pains_controller_spec.rb
+++ b/spec/controllers/pains_controller_spec.rb
@@ -26,7 +26,7 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 RSpec.describe PainsController, type: :controller do
-
+  login_user
   # This should return the minimal set of attributes required to create a valid
   # Pain. As you add validations to Pain, be sure to
   # adjust the attributes here as well.
@@ -38,15 +38,10 @@ RSpec.describe PainsController, type: :controller do
     skip("Add a hash of attributes invalid for your model")
   }
 
-  # This should return the minimal set of values that should be in the session
-  # in order to pass any filters (e.g. authentication) defined in
-  # PainsController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
-
   describe "GET #index" do
     it "returns a success response" do
       Pain.create! valid_attributes
-      get :index, params: {}, session: valid_session
+      get :index, params: {}
       expect(response).to be_successful
     end
   end
@@ -54,14 +49,14 @@ RSpec.describe PainsController, type: :controller do
   describe "GET #show" do
     it "returns a success response" do
       pain = Pain.create! valid_attributes
-      get :show, params: {id: pain.to_param}, session: valid_session
+      get :show, params: {id: pain.to_param}
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns a success response" do
-      get :new, params: {}, session: valid_session
+      get :new, params: {}
       expect(response).to be_successful
     end
   end
@@ -69,7 +64,7 @@ RSpec.describe PainsController, type: :controller do
   describe "GET #edit" do
     it "returns a success response" do
       pain = Pain.create! valid_attributes
-      get :edit, params: {id: pain.to_param}, session: valid_session
+      get :edit, params: {id: pain.to_param}
       expect(response).to be_successful
     end
   end
@@ -78,19 +73,19 @@ RSpec.describe PainsController, type: :controller do
     context "with valid params" do
       it "creates a new Pain" do
         expect {
-          post :create, params: {pain: valid_attributes}, session: valid_session
+          post :create, params: {pain: valid_attributes}
         }.to change(Pain, :count).by(1)
       end
 
       it "redirects to the created pain" do
-        post :create, params: {pain: valid_attributes}, session: valid_session
+        post :create, params: {pain: valid_attributes}
         expect(response).to redirect_to(Pain.last)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: {pain: invalid_attributes}, session: valid_session
+        post :create, params: {pain: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -104,14 +99,14 @@ RSpec.describe PainsController, type: :controller do
 
       it "updates the requested pain" do
         pain = Pain.create! valid_attributes
-        put :update, params: {id: pain.to_param, pain: new_attributes}, session: valid_session
+        put :update, params: {id: pain.to_param, pain: new_attributes}
         pain.reload
         skip("Add assertions for updated state")
       end
 
       it "redirects to the pain" do
         pain = Pain.create! valid_attributes
-        put :update, params: {id: pain.to_param, pain: valid_attributes}, session: valid_session
+        put :update, params: {id: pain.to_param, pain: valid_attributes}
         expect(response).to redirect_to(pain)
       end
     end
@@ -119,7 +114,7 @@ RSpec.describe PainsController, type: :controller do
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         pain = Pain.create! valid_attributes
-        put :update, params: {id: pain.to_param, pain: invalid_attributes}, session: valid_session
+        put :update, params: {id: pain.to_param, pain: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -129,13 +124,13 @@ RSpec.describe PainsController, type: :controller do
     it "destroys the requested pain" do
       pain = Pain.create! valid_attributes
       expect {
-        delete :destroy, params: {id: pain.to_param}, session: valid_session
+        delete :destroy, params: {id: pain.to_param}
       }.to change(Pain, :count).by(-1)
     end
 
     it "redirects to the pains list" do
       pain = Pain.create! valid_attributes
-      delete :destroy, params: {id: pain.to_param}, session: valid_session
+      delete :destroy, params: {id: pain.to_param}
       expect(response).to redirect_to(pains_url)
     end
   end

--- a/spec/controllers/physical_therapy_sessions_controller_spec.rb
+++ b/spec/controllers/physical_therapy_sessions_controller_spec.rb
@@ -26,7 +26,7 @@ require 'rails_helper'
 # `rails-controller-testing` gem.
 
 RSpec.describe PtSessionsController, type: :controller do
-
+  login_user
   # This should return the minimal set of attributes required to create a valid
   # PtSession. As you add validations to PtSession, be sure to
   # adjust the attributes here as well.
@@ -38,15 +38,10 @@ RSpec.describe PtSessionsController, type: :controller do
     skip("Add a hash of attributes invalid for your model")
   }
 
-  # This should return the minimal set of values that should be in the session
-  # in order to pass any filters (e.g. authentication) defined in
-  # PtSessionsController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
-
   describe "GET #index" do
     it "returns a success response" do
       PtSession.create! valid_attributes
-      get :index, params: {}, session: valid_session
+      get :index, params: {}
       expect(response).to be_successful
     end
   end
@@ -54,14 +49,14 @@ RSpec.describe PtSessionsController, type: :controller do
   describe "GET #show" do
     it "returns a success response" do
       pt_session = PtSession.create! valid_attributes
-      get :show, params: {id: pt_session.to_param}, session: valid_session
+      get :show, params: {id: pt_session.to_param}
       expect(response).to be_successful
     end
   end
 
   describe "GET #new" do
     it "returns a success response" do
-      get :new, params: {}, session: valid_session
+      get :new, params: {}
       expect(response).to be_successful
     end
   end
@@ -69,7 +64,7 @@ RSpec.describe PtSessionsController, type: :controller do
   describe "GET #edit" do
     it "returns a success response" do
       pt_session = PtSession.create! valid_attributes
-      get :edit, params: {id: pt_session.to_param}, session: valid_session
+      get :edit, params: {id: pt_session.to_param}
       expect(response).to be_successful
     end
   end
@@ -78,19 +73,19 @@ RSpec.describe PtSessionsController, type: :controller do
     context "with valid params" do
       it "creates a new PtSession" do
         expect {
-          post :create, params: {pt_session: valid_attributes}, session: valid_session
+          post :create, params: {pt_session: valid_attributes}
         }.to change(PtSession, :count).by(1)
       end
 
       it "redirects to the created pt_session" do
-        post :create, params: {pt_session: valid_attributes}, session: valid_session
+        post :create, params: {pt_session: valid_attributes}
         expect(response).to redirect_to(PtSession.last)
       end
     end
 
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'new' template)" do
-        post :create, params: {pt_session: invalid_attributes}, session: valid_session
+        post :create, params: {pt_session: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -104,14 +99,14 @@ RSpec.describe PtSessionsController, type: :controller do
 
       it "updates the requested pt_session" do
         pt_session = PtSession.create! valid_attributes
-        put :update, params: {id: pt_session.to_param, pt_session: new_attributes}, session: valid_session
+        put :update, params: {id: pt_session.to_param, pt_session: new_attributes}
         pt_session.reload
         skip("Add assertions for updated state")
       end
 
       it "redirects to the pt_session" do
         pt_session = PtSession.create! valid_attributes
-        put :update, params: {id: pt_session.to_param, pt_session: valid_attributes}, session: valid_session
+        put :update, params: {id: pt_session.to_param, pt_session: valid_attributes}
         expect(response).to redirect_to(pt_session)
       end
     end
@@ -119,7 +114,7 @@ RSpec.describe PtSessionsController, type: :controller do
     context "with invalid params" do
       it "returns a success response (i.e. to display the 'edit' template)" do
         pt_session = PtSession.create! valid_attributes
-        put :update, params: {id: pt_session.to_param, pt_session: invalid_attributes}, session: valid_session
+        put :update, params: {id: pt_session.to_param, pt_session: invalid_attributes}
         expect(response).to be_successful
       end
     end
@@ -129,13 +124,13 @@ RSpec.describe PtSessionsController, type: :controller do
     it "destroys the requested pt_session" do
       pt_session = PtSession.create! valid_attributes
       expect {
-        delete :destroy, params: {id: pt_session.to_param}, session: valid_session
+        delete :destroy, params: {id: pt_session.to_param}
       }.to change(PtSession, :count).by(-1)
     end
 
     it "redirects to the pt_sessions list" do
       pt_session = PtSession.create! valid_attributes
-      delete :destroy, params: {id: pt_session.to_param}, session: valid_session
+      delete :destroy, params: {id: pt_session.to_param}
       expect(response).to redirect_to(pt_sessions_url)
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,8 @@ require 'devise'
 require 'capybara/rails'
 require 'capybara/rspec'
 
+require_relative 'support/controller_macros'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -44,6 +46,9 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  config.include Devise::Test::ControllerHelpers, :type => :controller
+  config.extend ControllerMacros, :type => :controller
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
This should get all the controller tests passing for now, although there are some pending tests that can be tackled later on.

I used the login_user method at the start of all controllers in order to generate a current_user which makes these requests now valid.  The [devise docs](https://github.com/plataformatec/devise/wiki/How-To:-Test-controllers-with-Rails-(and-RSpec)#rails-3-rspec-scaffolds) recommended removing the `valid_session` boilerplate that rspec generates, since Devise has their own methods.