### PR TITLE
29 exercise index

### DIFF
--- a/app/assets/javascripts/exercises.js
+++ b/app/assets/javascripts/exercises.js
@@ -1,22 +1,24 @@
-document.addEventListener('DOMContentLoaded', function () {
-  let exerciseList = document.getElementById('exercise-list')
+function listToggler() {
+  document.addEventListener('DOMContentLoaded', function () {
+    let exerciseList = document.getElementById('exercise-list')
 
-  exerciseList.addEventListener('click', function (event) {
-    let element = event.target
-    if(element.classList.contains('exercise-description-toggle')){
-      let description = element.parentElement.parentElement.querySelector('.exercise-description');
-      if(element.classList.contains('fa-chevron-down')){
-        element.classList.remove('fa-chevron-down')
-        element.classList.add('fa-chevron-left')
-        description.style.display = 'block';
-      } else {
-        element.classList.remove('fa-chevron-left')
-        element.classList.add('fa-chevron-down')
-        description.style.display = 'none';
+    exerciseList.addEventListener('click', function (event) {
+      let element = event.target
+      if(element.classList.contains('exercise-description-toggle')){
+        let description = element.parentElement.parentElement.querySelector('.exercise-description');
+        if(element.classList.contains('fa-chevron-down')){
+          element.classList.remove('fa-chevron-down')
+          element.classList.add('fa-chevron-left')
+          description.style.display = 'block';
+        } else {
+          element.classList.remove('fa-chevron-left')
+          element.classList.add('fa-chevron-down')
+          description.style.display = 'none';
+        }
       }
-    }
+    });
   });
-});
+}
 
 
 function dropdownSwitcher() {

--- a/app/assets/javascripts/exercises.js
+++ b/app/assets/javascripts/exercises.js
@@ -1,3 +1,24 @@
+document.addEventListener('DOMContentLoaded', function () {
+  let exerciseList = document.getElementById('exercise-list')
+
+  exerciseList.addEventListener('click', function (event) {
+    let element = event.target
+    if(element.classList.contains('exercise-description-toggle')){
+      let description = element.parentElement.parentElement.querySelector('.exercise-description');
+      if(element.classList.contains('fa-chevron-down')){
+        element.classList.remove('fa-chevron-down')
+        element.classList.add('fa-chevron-left')
+        description.style.display = 'block';
+      } else {
+        element.classList.remove('fa-chevron-left')
+        element.classList.add('fa-chevron-down')
+        description.style.display = 'none';
+      }
+    }
+  });
+});
+
+
 function dropdownSwitcher() {
   document.addEventListener('DOMContentLoaded', function () {
     const exerciseDropdown = document.getElementById('exercise_log_exercise_id');

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -3,12 +3,12 @@ $default_text: #2b5f6e;
 $brand_main: #0994A1;
 $brand_main_lt: #AFE8ED;
 $secondary: #B1B1B1;
-$light-gray: #F1F1F1;
+$light_gray: #F1F1F1;
 $error: red;
 
-$pain-color: #F2B134;
-$exercise-color: #48AA6C;
-$therapy-color: #0994A1;
+$pain_color: #F2B134;
+$exercise_color: #48AA6C;
+$therapy_color: #0994A1;
 
 $orange: #ED553B;
-$dk-blue: #112F41;
+$dk_blue: #112F41;

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -18,19 +18,19 @@
 }
 
 .pain-button {
-  background-color: $pain-color;
-  border: 1px solid darken($pain-color, 10%);
-  &:hover { background-color: darken($pain-color, 10%) }
+  background-color: $pain_color;
+  border: 1px solid darken($pain_color, 10%);
+  &:hover { background-color: darken($pain_color, 10%) }
 }
 
 .exercise-button {
-  background-color: $exercise-color;
-  border: 1px solid darken($exercise-color, 10%);
-  &:hover { background-color: darken($exercise-color, 10%) }
+  background-color: $exercise_color;
+  border: 1px solid darken($exercise_color, 10%);
+  &:hover { background-color: darken($exercise_color, 10%) }
 }
 
 .therapy-button {
-  background-color: $therapy-color;
-  border: 1px solid darken($therapy-color, 10%);
-  &:hover { background-color: darken($therapy-color, 10%) }
+  background-color: $therapy_color;
+  border: 1px solid darken($therapy_color, 10%);
+  &:hover { background-color: darken($therapy_color, 10%) }
 }

--- a/app/assets/stylesheets/exercises.scss
+++ b/app/assets/stylesheets/exercises.scss
@@ -1,3 +1,14 @@
-// Place all the styles related to the exercises controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+@import 'variables';
+
+article.exercise-list-item {
+  border-top: 1px solid $light_gray;
+  color: $default_text;
+  padding: 0.6rem;
+  h3 {
+    font-size: 1.25rem;
+    margin-bottom: 0px;
+    a { color: $default_text; }
+    i { float: right; }
+  }
+  p.exercise-description { margin-bottom: 0px; }
+}

--- a/app/assets/stylesheets/logs.scss
+++ b/app/assets/stylesheets/logs.scss
@@ -11,7 +11,7 @@
   margin-bottom: 1rem;
   a { color: $default_text; }
   &:hover {
-    background-color: $light-gray;
+    background-color: $light_gray;
     a { text-decoration: none; }
   }
 }
@@ -36,10 +36,10 @@
   .card-title { color: $color; }
 }
 
-.log-type-pain { @include log-type-color($pain-color); }
-.log-type-exercise { @include log-type-color($exercise-color); }
-.log-type-therapy { @include log-type-color($therapy-color); }
+.log-type-pain { @include log-type-color($pain_color); }
+.log-type-exercise { @include log-type-color($exercise_color); }
+.log-type-therapy { @include log-type-color($therapy_color); }
 
-.log-border-exercise { border: 1px solid $exercise-color; }
-.log-border-pain { border: 1px solid $pain-color; }
-.log-border-therapy { border: 1px solid $therapy-color; }
+.log-border-exercise { border: 1px solid $exercise_color; }
+.log-border-pain { border: 1px solid $pain_color; }
+.log-border-therapy { border: 1px solid $therapy_color; }

--- a/app/assets/stylesheets/rep_counter.scss
+++ b/app/assets/stylesheets/rep_counter.scss
@@ -2,7 +2,7 @@
 
 .counter-number-big {
   font-size: 6rem;
-  color: $exercise-color;
+  color: $exercise_color;
   font-weight: bold;
 }
 

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -1,6 +1,6 @@
 @import 'variables';
 
-body { background-color: $dk-blue; }
+body { background-color: $dk_blue; }
 
 .fa-nav {
   border-radius: 50%;

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -20,7 +20,7 @@ class Exercise < ApplicationRecord
 
   class << self
     def by_name
-      order(:name)
+      order('lower(name) ASC')
     end
 
     def has_logs

--- a/app/views/exercises/index.html.erb
+++ b/app/views/exercises/index.html.erb
@@ -21,3 +21,7 @@
     </article>
   <% end %>
 </section>
+
+<script type="text/javascript">
+  listToggler();
+</script>

--- a/app/views/exercises/index.html.erb
+++ b/app/views/exercises/index.html.erb
@@ -11,22 +11,13 @@
 
 <p class='clear_search'><%= link_to 'Clear Search', exercises_path %></p>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>Exercise</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @exercises.each do |exercise| %>
-      <tr>
-        <td><%= link_to exercise.name, edit_exercise_path(exercise) %>
-        <td><strong><%= exercise.default_sets %> sets of <%= exercise.default_reps %> with <%= exercise.default_rep_length %> sec hold <%= 'per side' if exercise.default_per_side %></strong><br>
-          <%= exercise.description %>
-      </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<section id='exercise-list'>
+  <% @exercises.each do |exercise| %>
+    <article class='exercise-list-item'>
+      <h3><%= link_to exercise.name, edit_exercise_path(exercise) %> <i class='exercise-description-toggle fal fa-chevron-down'></i></h3>
+      <p class='exercise-description hidden'><strong><%= exercise.default_sets %> sets of <%= exercise.default_reps %> with <%= exercise.default_rep_length %> sec hold <%= 'per side' if exercise.default_per_side %></strong><br>
+        <%= exercise.description %>
+      </p>
+    </article>
+  <% end %>
+</section>


### PR DESCRIPTION
Closes #29 

Secondary information is now hidden behind the exercise name. This info can be seen by toggling the arrow on the right side. 

## Before
<img width="230" alt="Screenshot 2019-05-03 18 52 24" src="https://user-images.githubusercontent.com/8680712/57170746-9e6dc880-6dd4-11e9-9445-27febdbddc43.png">

## After
<img width="230" alt="Screenshot 2019-05-19 18 21 03" src="https://user-images.githubusercontent.com/8680712/57989623-0a059600-7a63-11e9-9f66-b4474f6ecb80.png">
<img width="230" alt="Screenshot 2019-05-19 18 21 20" src="https://user-images.githubusercontent.com/8680712/57989624-0a059600-7a63-11e9-86a7-6b08642fcdee.png">
