### PR TITLE
Facilitate pain log data entry

### DIFF
--- a/app/assets/javascripts/exercises.js
+++ b/app/assets/javascripts/exercises.js
@@ -21,7 +21,7 @@ function listToggler() {
 }
 
 
-function dropdownSwitcher() {
+function exerciseDropdownSwitcher() {
   document.addEventListener('DOMContentLoaded', function () {
     const exerciseDropdown = document.getElementById('exercise_log_exercise_id');
     const initialExerciseId = exerciseDropdown.options[exerciseDropdown.selectedIndex].value;

--- a/app/assets/javascripts/pain_logs.js
+++ b/app/assets/javascripts/pain_logs.js
@@ -1,0 +1,31 @@
+function painLevelDropdownSwitcher() {
+  document.addEventListener('DOMContentLoaded', function () {
+    const painDropdown = document.getElementById('pain_log_pain_id');
+    const painLevel = document.getElementById('pain_log_pain_level');
+    const description = document.getElementById('pain_log_pain_description');
+    const trigger = document.getElementById('pain_log_trigger');
+
+    function populateNoPainData() {
+      painLevel.value = 0;
+      description.value = 'none';
+      trigger.focus();
+      trigger.select();
+    }
+
+    function resetData() {
+      painLevel.value = null;
+      description.value = '';
+    }
+
+    painDropdown.addEventListener('change', function (event) {
+      const selectedPainItem = painDropdown.options[painDropdown.selectedIndex].text.toLowerCase();
+      event.preventDefault();
+
+      if (selectedPainItem === 'none') {
+        populateNoPainData();
+      } else {
+        resetData();
+      }
+    })
+  });
+}

--- a/app/models/pain.rb
+++ b/app/models/pain.rb
@@ -7,7 +7,7 @@ class Pain < ApplicationRecord
   has_many :pain_logs, dependent: :destroy
   has_many :logs, foreign_key: 'pain_id', class_name: 'PainLog', dependent: :destroy
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   class << self
     def has_logs

--- a/app/views/exercise_logs/new.html.erb
+++ b/app/views/exercise_logs/new.html.erb
@@ -5,5 +5,5 @@
 <%= render 'form', exercise_log: @exercise_log, url: exercise_logs_path %>
 
 <script type='text/javascript'>
-  dropdownSwitcher();
+  exerciseDropdownSwitcher();
 </script>

--- a/app/views/pain_logs/_form.html.erb
+++ b/app/views/pain_logs/_form.html.erb
@@ -17,18 +17,18 @@
   <div class='form-row'>
     <div class='col'>
       <div class='field'>
-        <%= form.label 'Pain Level (0 = none, 10 = worst)', class: 'required' %>
-        <%= form.number_field :pain_level, selected: last_log(:pain_logs, :pain_level), class: 'form-control' %>
-      </div>
-    </div>
-
-    <div class='col'>
-      <div class='field'>
         <%= form.label 'Pain Type', class: 'required' %>
         <%= form.collection_select :pain_id,
         Pain.all.order(:name), :id, :name,
         { include_blank: false },
         class: 'form-control' %>
+      </div>
+    </div>
+
+    <div class='col'>
+      <div class='field'>
+        <%= form.label 'Pain Level (0 = none, 10 = worst)', class: 'required' %>
+        <%= form.number_field :pain_level, selected: last_log(:pain_logs, :pain_level), class: 'form-control' %>
       </div>
     </div>
   </div>

--- a/app/views/pain_logs/new.html.erb
+++ b/app/views/pain_logs/new.html.erb
@@ -3,3 +3,7 @@
 <h1>New Pain Log</h1>
 
 <%= render 'form', pain_log: @pain_log %>
+
+<script type='text/javascript'>
+  painLevelDropdownSwitcher();
+</script>

--- a/spec/models/pain_spec.rb
+++ b/spec/models/pain_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pain, type: :model do
 
   context 'validations' do
     it { should validate_presence_of(:name) }
-    it { should validate_uniqueness_of(:name) }
+    it { should validate_uniqueness_of(:name).case_insensitive }
   end
 
   describe 'self.has_logs' do


### PR DESCRIPTION
This adds some JS assistance to the pain logs form so that fields are populated when a person enters a "none" entry for pain. Since `pain`s are user-generated, it is not guaranteed that every use will have a "none" `pain`. It's fine with me to have this as sort of an easter egg feature. Also, since i am my only user, i want to make this easy for myself to use.