### PR TITLE
55 landing page content

### DIFF
--- a/app/helpers/logs_helper.rb
+++ b/app/helpers/logs_helper.rb
@@ -12,10 +12,18 @@ module LogsHelper
 
   def last_homework
     return false if current_user.pt_sessions.last.nil?
-    
+
     {
       notes: current_user.pt_sessions.last&.homework,
       exercises: current_user.pt_sessions.last&.homework_exercises
     }
+  end
+
+  def user_has_all_required_data(user)
+    user.body_parts.any? && user.pains.any? && user.exercises.any?
+  end
+
+  def user_needs_data_for_section(user, attr)
+    user.send(attr).empty?
   end
 end

--- a/app/models/body_part.rb
+++ b/app/models/body_part.rb
@@ -8,5 +8,9 @@ class BodyPart < ApplicationRecord
   has_many :pain_logs, dependent: :destroy
   has_many :pt_sessions, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: true
+  validates :name,
+            presence: true,
+            uniqueness: {
+              case_sensitive: false,
+              scope: :user_id }
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -18,7 +18,9 @@ class Exercise < ApplicationRecord
 
   validates :name,
             presence: true,
-            uniqueness: true
+            uniqueness: {
+              case_sensitive: false,
+              scope: :user_id }
 
   class << self
     def has_logs

--- a/app/models/pain.rb
+++ b/app/models/pain.rb
@@ -7,7 +7,10 @@ class Pain < ApplicationRecord
   has_many :pain_logs, dependent: :destroy
   has_many :logs, foreign_key: 'pain_id', class_name: 'PainLog', dependent: :destroy
 
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, presence: true,
+                   uniqueness: {
+                     case_sensitive: false,
+                     scope: :user_id }
 
   class << self
     def has_logs

--- a/app/views/body_parts/index.html.erb
+++ b/app/views/body_parts/index.html.erb
@@ -2,10 +2,16 @@
 
 <h1>Body Parts</h1>
 
-<%= render partial: 'shared/search_form', locals: { url: body_parts_path } %>
+<% if @body_parts.present? %>
+  <%= render partial: 'shared/search_form', locals: { url: body_parts_path } %>
 
-<% @body_parts.each do |body_part| %>
-  <article class='index-list-item'>
-    <h3><%= link_to body_part.name, edit_body_part_path(body_part) %></h3>
-  </article>
+  <% @body_parts.each do |body_part| %>
+    <article class='index-list-item'>
+      <h3><%= link_to body_part.name, edit_body_part_path(body_part) %></h3>
+    </article>
+  <% end %>
+  
+<% else %>
+  <p>Create a New Body Part</p>
+  <%= link_to 'New Body Part', new_body_part_path, class: button_class('primary btn-wide') %>
 <% end %>

--- a/app/views/body_parts/new.html.erb
+++ b/app/views/body_parts/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New Body Part</h1>
 
+<p>Examples: right knee, left wrist, right ankle</p>
 <%= render 'form', body_part: @body_part %>
 
 <%= link_to 'Back', body_parts_path %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,27 +3,27 @@
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= devise_error_messages! %>
 
-  <div class="field">
+  <div class='field'>
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
   </div>
 
-  <div class="field">
+  <div class='field'>
     <%= f.label :password %>
     <% if @minimum_password_length %>
     <em>(<%= @minimum_password_length %> characters minimum)</em>
     <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
+    <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
   </div>
 
-  <div class="field">
+  <div class='field'>
     <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control' %>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
+  <div class='actions'>
+    <%= f.submit 'Sign up' %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<%= render 'devise/shared/links' %>

--- a/app/views/exercises/index.html.erb
+++ b/app/views/exercises/index.html.erb
@@ -2,18 +2,24 @@
 
 <h1>Exercises</h1>
 
-<%= render partial: 'shared/search_form', locals: { url: exercises_path } %>
+<% if @exercises.present? %>
+  <%= render partial: 'shared/search_form', locals: { url: exercises_path } %>
 
-<section id='exercise-list'>
-  <% @exercises.each do |exercise| %>
-    <article class='index-list-item'>
-      <h3><%= link_to exercise.name, edit_exercise_path(exercise) %> <i class='exercise-description-toggle fal fa-chevron-down'></i></h3>
-      <p class='exercise-description hidden'><strong><%= exercise.default_sets %> sets of <%= exercise.default_reps %> with <%= exercise.default_rep_length %> sec hold <%= 'per side' if exercise.default_per_side %></strong><br>
-        <%= exercise.description %>
-      </p>
-    </article>
-  <% end %>
-</section>
+  <section id='exercise-list'>
+    <% @exercises.each do |exercise| %>
+      <article class='index-list-item'>
+        <h3><%= link_to exercise.name, edit_exercise_path(exercise) %> <i class='exercise-description-toggle fal fa-chevron-down'></i></h3>
+        <p class='exercise-description hidden'><strong><%= exercise.default_sets %> sets of <%= exercise.default_reps %> with <%= exercise.default_rep_length %> sec hold <%= 'per side' if exercise.default_per_side %></strong><br>
+          <%= exercise.description %>
+        </p>
+      </article>
+    <% end %>
+  </section>
+
+<% else %>
+  <p>Create a New Exercise</p>
+  <%= link_to 'New Exercise', new_exercise_path, class: button_class('primary btn-wide') %>
+<% end %>
 
 <script type="text/javascript">
   listToggler();

--- a/app/views/logs/_new_user_welcome.html.erb
+++ b/app/views/logs/_new_user_welcome.html.erb
@@ -1,0 +1,30 @@
+<div class='white-container'>
+  <h1>Welcome to Therapy Tracker!</h1>
+  <p>Get started tracking your physical therapy progress:</p>
+  <ol>
+    <li>Build some body parts! Start with the Target Body Part you're working on:<br>
+      <%= link_to 'Build Body Parts', new_body_part_path, class: button_class('primary btn-wide') %>
+    </li>
+    <li>
+      Create Common Pains. Enter the types of pains you usually experience:
+      <%= link_to 'Create Pains', new_pain_path, class: button_class('primary btn-wide') %>
+    </li>
+    <li>
+      Enter the Exercises you'll be doing.
+      <%= link_to 'Build Body Parts', new_body_part_path, class: button_class('primary btn-wide') %>
+    </li>
+    <li>
+      Log Something! <br>
+      <%#= render partial: 'shared/add_log_buttons' %>
+
+      Pain: You can create a log for any time you experience a pain. It's important to log pain to help you track your progress.
+      <%= link_to 'Log a Pain', new_pain_log_path, class: button_class('primary btn-wide') %>
+
+      Exercise: Each time you exercise, log it! This will help your therapist to know what's working for you.
+      <%= link_to 'Log an Exercise', new_exercise_log_path, class: button_class('primary btn-wide') %>
+
+      Physical Therapy Session:
+      <%= link_to 'Log a PT Session', new_pt_session_path, class: button_class('primary btn-wide') %>
+    </li>
+  </ol>
+</div><!-- white-container -->

--- a/app/views/logs/_new_user_welcome.html.erb
+++ b/app/views/logs/_new_user_welcome.html.erb
@@ -1,30 +1,53 @@
 <div class='white-container'>
   <h1>Welcome to Therapy Tracker!</h1>
-  <p>Get started tracking your physical therapy progress:</p>
-  <ol>
-    <li>Build some body parts! Start with the Target Body Part you're working on:<br>
-      <%= link_to 'Build Body Parts', new_body_part_path, class: button_class('primary btn-wide') %>
-    </li>
-    <li>
-      Create Common Pains. Enter the types of pains you usually experience:
-      <%= link_to 'Create Pains', new_pain_path, class: button_class('primary btn-wide') %>
-    </li>
-    <li>
-      Enter the Exercises you'll be doing.
-      <%= link_to 'Build Body Parts', new_body_part_path, class: button_class('primary btn-wide') %>
-    </li>
-    <li>
-      Log Something! <br>
-      <%#= render partial: 'shared/add_log_buttons' %>
+  <p>Get started tracking your physical therapy progress.</p>
 
-      Pain: You can create a log for any time you experience a pain. It's important to log pain to help you track your progress.
-      <%= link_to 'Log a Pain', new_pain_log_path, class: button_class('primary btn-wide') %>
+  <% if user_has_all_required_data(current_user) %>
+    <h3>Log Something!</h3>
+    <%= render partial: 'shared/add_log_buttons' %>
 
-      Exercise: Each time you exercise, log it! This will help your therapist to know what's working for you.
-      <%= link_to 'Log an Exercise', new_exercise_log_path, class: button_class('primary btn-wide') %>
+    <h4>Pain:</h4> You can create a log for any time you experience a pain. It's important to log pain to help you track your progress.
+    <h4>Exercise:</h4> Each time you exercise, log it! This will help your therapist to know what's working for you.
+    <h4>Physical Therapy Session:</h4> Track notes, progress, exercises, and homework for your physical therapy sessions.
+  <% else %>
 
-      Physical Therapy Session:
-      <%= link_to 'Log a PT Session', new_pt_session_path, class: button_class('primary btn-wide') %>
-    </li>
-  </ol>
+    <% if user_needs_data_for_section(current_user, 'body_parts') %>
+    <div class='row'>
+      <div class='col-6'>
+        <h3>What Body Part are you Targeting?</h3>
+        <p>Start with the Target Body Part you're working on.</p>
+      </div>
+
+      <div class='col-6'>
+        <%= link_to 'Create Body Part', new_body_part_path, class: button_class('primary btn-wide') %>
+      </div>
+    </div> <!-- row -->
+    <% end %>
+
+    <% if user_needs_data_for_section(current_user, 'pains') %>
+    <div class='row'>
+      <div class='col-6'>
+        <h3>What Kind of Pain do You Feel?</h3>
+        <p>Stabbing? Dull? Achey? Enter the types of pains you usually experience.</p>
+      </div>
+
+      <div class='col-6'>
+        <%= link_to 'Create a Pain Type', new_pain_path, class: button_class('primary btn-wide') %>
+      </div>
+    </div> <!-- row -->
+    <% end %>
+
+    <% if user_needs_data_for_section(current_user, 'exercises') %>
+    <div class='row'>
+      <div class='col-6'>
+        <h3>Input the Exercise Types You're Doing</h3>
+        <p>Leg lifts? Arm raises? Maybe you're doing "wall angels" like everyone with desk jobs does. Enter them here!</p>
+      </div>
+
+      <div class='col-6'>
+        <%= link_to 'Build Exercise', new_exercise_path, class: button_class('primary btn-wide') %>
+      </div>
+    </div> <!-- row -->
+    <% end %>
+  <% end %><!-- if user_has_all_required_data -->
 </div><!-- white-container -->

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,12 +1,43 @@
-<%= render partial: 'shared/add_log_buttons' %>
+<% if @logs.present? %>
+  <%= render partial: 'shared/add_log_buttons' %>
 
-<% if last_homework %>
-  <%= render partial: 'pt_sessions/homework', locals: { homework: last_homework } %>
-<% end %>
+  <% if last_homework %>
+    <%= render partial: 'pt_sessions/homework', locals: { homework: last_homework } %>
+  <% end %>
 
-<% @logs.each do |log| %>
-  <%= render log %>
+  <% @logs.each do |log| %>
+    <%= render log %>
+  <% end %>
+  <br>
+<% else %>
+  <div class='white-container'>
+    <h1>Welcome to Therapy Tracker!</h1>
+    <p>Get started tracking your physical therapy progress:</p>
+    <ol>
+      <li>Build some body parts! Start with the Target Body Part you're working on:<br>
+        <%= link_to 'Build Body Parts', new_body_part_path, class: button_class('primary btn-wide') %>
+      </li>
+      <li>
+        Create Common Pains. Enter the types of pains you usually experience:
+        <%= link_to 'Create Pains', new_pain_path, class: button_class('primary btn-wide') %>
+      </li>
+      <li>
+        Enter the Exercises you'll be doing.
+        <%= link_to 'Build Body Parts', new_body_part_path, class: button_class('primary btn-wide') %>
+      </li>
+      <li>
+        Log Something! <br>
+        Pain: You can create a log for any time you experience a pain. It's important to log pain to help you track your progress.
+        <%= link_to 'Log a Pain', new_pain_log_path, class: button_class('primary btn-wide') %>
+
+        Exercise: Each time you exercise, log it! This will help your therapist to know what's working for you.
+        <%= link_to 'Log an Exercise', new_exercise_log_path, class: button_class('primary btn-wide') %>
+
+        Physical Therapy Session:
+        <%= link_to 'Log a PT Session', new_pt_session_path, class: button_class('primary btn-wide') %>  
+      </li>
+    </ol>
+  </div><!-- white-container -->
 <% end %>
-<br>
 
 <%= will_paginate @logs, :page_links => false %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -9,35 +9,8 @@
     <%= render log %>
   <% end %>
   <br>
+  <%= will_paginate @logs, :page_links => false %>
+
 <% else %>
-  <div class='white-container'>
-    <h1>Welcome to Therapy Tracker!</h1>
-    <p>Get started tracking your physical therapy progress:</p>
-    <ol>
-      <li>Build some body parts! Start with the Target Body Part you're working on:<br>
-        <%= link_to 'Build Body Parts', new_body_part_path, class: button_class('primary btn-wide') %>
-      </li>
-      <li>
-        Create Common Pains. Enter the types of pains you usually experience:
-        <%= link_to 'Create Pains', new_pain_path, class: button_class('primary btn-wide') %>
-      </li>
-      <li>
-        Enter the Exercises you'll be doing.
-        <%= link_to 'Build Body Parts', new_body_part_path, class: button_class('primary btn-wide') %>
-      </li>
-      <li>
-        Log Something! <br>
-        Pain: You can create a log for any time you experience a pain. It's important to log pain to help you track your progress.
-        <%= link_to 'Log a Pain', new_pain_log_path, class: button_class('primary btn-wide') %>
-
-        Exercise: Each time you exercise, log it! This will help your therapist to know what's working for you.
-        <%= link_to 'Log an Exercise', new_exercise_log_path, class: button_class('primary btn-wide') %>
-
-        Physical Therapy Session:
-        <%= link_to 'Log a PT Session', new_pt_session_path, class: button_class('primary btn-wide') %>  
-      </li>
-    </ol>
-  </div><!-- white-container -->
+  <%= render 'new_user_welcome' %>
 <% end %>
-
-<%= will_paginate @logs, :page_links => false %>

--- a/app/views/pains/index.html.erb
+++ b/app/views/pains/index.html.erb
@@ -2,10 +2,15 @@
 
 <h1>Pains</h1>
 
-<%= render partial: 'shared/search_form', locals: { url: pains_path } %>
+<% if @pains.present? %>
+  <%= render partial: 'shared/search_form', locals: { url: pains_path } %>
 
-<% @pains.each do |pain| %>
-  <article class='index-list-item'>
-    <h3><%= link_to pain.name, edit_pain_path(pain) %></h3>
-  </article>
+  <% @pains.each do |pain| %>
+    <article class='index-list-item'>
+      <h3><%= link_to pain.name, edit_pain_path(pain) %></h3>
+    </article>
+  <% end %>
+<% else %>
+  <p>Create a New Pain</p>
+  <%= link_to 'New Pain', new_pain_path, class: button_class('primary btn-wide') %>
 <% end %>

--- a/app/views/pains/new.html.erb
+++ b/app/views/pains/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New Pain</h1>
 
+<p>Some examples: sharp, throbbing, dull</p>
 <%= render 'form', pain: @pain %>
 
 <%= link_to 'Back', pains_path %>

--- a/spec/models/body_part_spec.rb
+++ b/spec/models/body_part_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BodyPart, type: :model do
 
   context 'validations' do
     it { should validate_presence_of(:name) }
-    it { should validate_uniqueness_of(:name) }
+    it { should validate_uniqueness_of(:name).case_insensitive.scoped_to(:user_id) }
   end
 
   describe 'self.by_name' do

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Exercise, type: :model do
   end
 
   context 'validations' do
-    it { should validate_uniqueness_of(:name) }
+    it { should validate_uniqueness_of(:name).case_insensitive.scoped_to(:user_id) }
 
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:description) }

--- a/spec/models/pain_spec.rb
+++ b/spec/models/pain_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Pain, type: :model do
 
   context 'validations' do
     it { should validate_presence_of(:name) }
-    it { should validate_uniqueness_of(:name).case_insensitive }
+    it { should validate_uniqueness_of(:name).case_insensitive.scoped_to(:user_id) }
   end
 
   describe 'self.has_logs' do


### PR DESCRIPTION
Closes #55 

## Problem
When a new user signs up, the welcome page is empty:
<img width="400" alt="Screenshot 2019-06-01 12 23 05" src="https://user-images.githubusercontent.com/8680712/58751731-21cc1980-8468-11e9-807e-56c783c2a0f9.png">

## Solution
Create content to guide a user through setting up the necessary data and getting started. When a user has not set up `pains`, `exercises`, or `body_parts`, these sections appear, prompting them to do so:
<img width="400" alt="Screenshot 2019-06-01 12 22 48" src="https://user-images.githubusercontent.com/8680712/58751730-21cc1980-8468-11e9-810c-ce51de0d0573.png">

Once a user has set up those 3 pieces of data, those parts of the view go away and they are prompted to make a new log. 
<img width="400" alt="Screenshot 2019-06-01 12 23 29" src="https://user-images.githubusercontent.com/8680712/58751732-21cc1980-8468-11e9-9c71-510e7dd588c9.png">

Once a user logs _anything_ this content goes away and they get to see their logs.
<img width="400" alt="Screenshot 2019-06-01 12 27 09" src="https://user-images.githubusercontent.com/8680712/58751752-9acb7100-8468-11e9-9efd-000d4efce148.png">

