### PR TITLE
71 active inactive body parts

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -4,6 +4,7 @@ $brand_main: #0994A1;
 $brand_main_lt: #AFE8ED;
 $secondary: #B1B1B1;
 $light_gray: #F1F1F1;
+$medium_gray: #CCCCCC;
 $error: red;
 
 $pain_color: #F2B134;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,0 +1,20 @@
+@import 'variables';
+
+.field {
+  label {
+    font-weight: bold;
+    text-transform: capitalize;
+    margin-top: 1rem;
+  }
+}
+
+label.required:after {
+  content: ' *';
+  font-size: 0.85rem;
+  color: $pain_color;
+}
+
+.field_with_errors .form-control {
+  border: 1px solid $error;
+  border-radius: 0.25rem;
+}

--- a/app/assets/stylesheets/search_bar.scss
+++ b/app/assets/stylesheets/search_bar.scss
@@ -6,7 +6,7 @@
   float: right;
   top: 25px;
   right: 14px;
-  color: #CCC;
+  color: $medium_gray;
 }
 
 .clear_search {
@@ -14,16 +14,6 @@
   margin-bottom: 2em;
   text-align: center;
   a {
-    color: #CCC;
+    color: $medium_gray;
   }
-}
-
-label.required:after {
-  content: ' *';
-  font-size: 0.85rem;
-}
-
-.field_with_errors .form-control {
-  border: 1px solid $error;
-  border-radius: 0.25rem;
 }

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -41,6 +41,10 @@ body { background-color: $dk_blue; }
   vertical-align: middle;
 }
 
+.text-subtle {
+  font-style: italic;
+  color: $medium_gray;
+}
 
 /* Index Pages */
 article.index-list-item {

--- a/app/controllers/body_parts_controller.rb
+++ b/app/controllers/body_parts_controller.rb
@@ -48,7 +48,7 @@ class BodyPartsController < ApplicationController
   end
 
   def body_part_params
-    params.require(:body_part).permit(:name)
+    params.require(:body_part).permit(:archived, :name)
   end
 
   def authorize_body_part

--- a/app/models/body_part.rb
+++ b/app/models/body_part.rb
@@ -13,4 +13,8 @@ class BodyPart < ApplicationRecord
             uniqueness: {
               case_sensitive: false,
               scope: :user_id }
+
+  def self.active
+    where(archived: false)
+  end
 end

--- a/app/views/body_parts/_form.html.erb
+++ b/app/views/body_parts/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class='field'>
     <%= form.label :name, class: 'required' %>
-    <%= form.text_field :name, class: 'form-control' %>
+    <%= form.text_field :name, required: true, class: 'form-control' %>
   </div>
 
   <div class='field'>

--- a/app/views/body_parts/_form.html.erb
+++ b/app/views/body_parts/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: body_part, local: true) do |form| %>
   <% if body_part.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(body_part.errors.count, "error") %> prohibited this body_part from being saved:</h2>
+    <div id='error_explanation'>
+      <h2><%= pluralize(body_part.errors.count, 'error') %> prohibited this body_part from being saved:</h2>
 
       <ul>
       <% body_part.errors.full_messages.each do |message| %>
@@ -11,12 +11,12 @@
     </div>
   <% end %>
 
-  <div class="field">
+  <div class='field'>
     <%= form.label :name, class: 'required' %>
     <%= form.text_field :name, class: 'form-control' %>
   </div>
 
-  <div class="actions mt-3 mb-3">
+  <div class='actions mt-3 mb-3'>
     <%= form.submit class: button_class('success') %>
     <%= link_to 'Cancel', body_parts_path, class: button_class('primary pull-right') %>
   </div>

--- a/app/views/body_parts/_form.html.erb
+++ b/app/views/body_parts/_form.html.erb
@@ -16,6 +16,12 @@
     <%= form.text_field :name, class: 'form-control' %>
   </div>
 
+  <div class='field'>
+    <%= form.label 'Archive this Body Part' %>
+    <p>Checking this box will hide this body part from dropdown menus.</p>
+    <%= form.check_box :archived, class: 'form-control' %>
+  </div>
+
   <div class='actions mt-3 mb-3'>
     <%= form.submit class: button_class('success') %>
     <%= link_to 'Cancel', body_parts_path, class: button_class('primary pull-right') %>

--- a/app/views/body_parts/index.html.erb
+++ b/app/views/body_parts/index.html.erb
@@ -7,7 +7,12 @@
 
   <% @body_parts.each do |body_part| %>
     <article class='index-list-item'>
-      <h3><%= link_to body_part.name, edit_body_part_path(body_part) %></h3>
+      <h3>
+        <%= link_to body_part.name, edit_body_part_path(body_part) %>
+        <% if body_part.archived? %>
+          <span class='text-subtle'>(archived)</span>
+        <% end %>
+      </h3>
     </article>
   <% end %>
 

--- a/app/views/exercise_logs/_form.html.erb
+++ b/app/views/exercise_logs/_form.html.erb
@@ -4,8 +4,8 @@
   <div class='field'>
     <%= form.label 'Target Body Part', class: 'required' %>
     <%= form.collection_select :body_part_id,
-    current_user.body_parts, :id, :name,
     { include_blank: false },
+    current_user.body_parts.active, :id, :name,
     class: 'form-control' %>
   </div>
 

--- a/app/views/exercise_logs/_form.html.erb
+++ b/app/views/exercise_logs/_form.html.erb
@@ -4,14 +4,14 @@
   <div class='field'>
     <%= form.label 'Target Body Part', class: 'required' %>
     <%= form.collection_select :body_part_id,
-    { include_blank: false },
     current_user.body_parts.active, :id, :name,
+    { include_blank: false, required: true },
     class: 'form-control' %>
   </div>
 
   <div class='field'>
     <%= form.label 'When', class: 'required' %><br>
-    <%= form.datetime_select :datetime_occurred, ampm: true, minute_step: 15, value: Date.today, class: 'form-control' %>
+    <%= form.datetime_select :datetime_occurred, ampm: true, minute_step: 15, value: Date.today, required: true, class: 'form-control' %>
   </div>
 
   <div class='field'>
@@ -19,6 +19,7 @@
     <%= form.collection_select :exercise_id,
     current_user.exercises.by_name, :id, :name,
     { prompt: '--Select--' },
+    required: true,
     class: 'form-control' %>
   </div>
 
@@ -26,21 +27,21 @@
     <div class='col'>
       <div class='field'>
         <%= form.label :sets, class: 'required' %>
-        <%= form.number_field :sets, class: 'form-control' %>
+        <%= form.number_field :sets, required: true, class: 'form-control' %>
       </div>
     </div>
 
     <div class='col'>
       <div class='field'>
         <%= form.label :reps, class: 'required' %>
-        <%= form.number_field :reps, class: 'form-control' %>
+        <%= form.number_field :reps, required: true, class: 'form-control' %>
       </div>
     </div>
 
     <div class='col'>
       <div class='field'>
         <%= form.label :rep_length, class: 'required' %>
-        <%= form.number_field :rep_length, class: 'form-control' %>
+        <%= form.number_field :rep_length, required: true, class: 'form-control' %>
       </div>
     </div>
 

--- a/app/views/exercises/_form.html.erb
+++ b/app/views/exercises/_form.html.erb
@@ -3,26 +3,26 @@
 
   <div class="field">
     <%= form.label :name, class: 'required' %>
-    <%= form.text_field :name, class: 'form-control' %>
+    <%= form.text_field :name, required: true, class: 'form-control' %>
   </div>
 
   <div class="form-row">
     <div class="col">
       <div class="field">
         <%= form.label :default_sets, class: 'required' %>
-        <%= form.number_field :default_sets, class: 'form-control' %>
+        <%= form.number_field :default_sets, required: true, class: 'form-control' %>
       </div>
     </div>
     <div class="col">
       <div class="field">
         <%= form.label :default_reps, class: 'required' %>
-        <%= form.number_field :default_reps, class: 'form-control' %>
+        <%= form.number_field :default_reps, required: true, class: 'form-control' %>
       </div>
     </div>
     <div class="col">
       <div class="field">
         <%= form.label :default_rep_length, class: 'required' %>
-        <%= form.number_field :default_rep_length, placeholder: 'seconds', class: 'form-control' %>
+        <%= form.number_field :default_rep_length, placeholder: 'seconds', required: true, class: 'form-control' %>
       </div>
     </div>
     <div class="col">
@@ -40,7 +40,7 @@
 
   <div class="field">
     <%= form.label :description, class: 'required' %>
-    <%= form.text_area :description, class: 'form-control' %>
+    <%= form.text_area :description, required: true, class: 'form-control' %>
   </div>
 
   <div class="actions mt-3 mb-3">

--- a/app/views/pain_logs/_form.html.erb
+++ b/app/views/pain_logs/_form.html.erb
@@ -4,8 +4,8 @@
   <div class='field'>
     <%= form.label 'Target Body Part', class: 'required' %>
     <%= form.collection_select :body_part_id,
-    current_user.body_parts, :id, :name,
     { include_blank: false },
+    current_user.body_parts.active, :id, :name,
     class: 'form-control' %>
   </div>
 

--- a/app/views/pain_logs/_form.html.erb
+++ b/app/views/pain_logs/_form.html.erb
@@ -4,14 +4,14 @@
   <div class='field'>
     <%= form.label 'Target Body Part', class: 'required' %>
     <%= form.collection_select :body_part_id,
-    { include_blank: false },
     current_user.body_parts.active, :id, :name,
+    { include_blank: false, required: true },
     class: 'form-control' %>
   </div>
 
   <div class='field'>
     <%= form.label 'When', class: 'required' %><br>
-    <%= form.datetime_select :datetime_occurred, ampm: true, minute_step: 15, value: Date.today, class: 'form-control' %>
+    <%= form.datetime_select :datetime_occurred, ampm: true, minute_step: 15, value: Date.today, required: true, class: 'form-control' %>
   </div>
 
   <div class='form-row'>
@@ -20,7 +20,7 @@
         <%= form.label 'Pain Type', class: 'required' %>
         <%= form.collection_select :pain_id,
         current_user.pains.by_name, :id, :name,
-        { include_blank: false },
+        { include_blank: false, required: true },
         class: 'form-control' %>
       </div>
     </div>
@@ -28,19 +28,19 @@
     <div class='col'>
       <div class='field'>
         <%= form.label 'Pain Level (0 = none, 10 = worst)', class: 'required' %>
-        <%= form.number_field :pain_level, selected: last_log(:pain_logs, :pain_level), class: 'form-control' %>
+        <%= form.number_field :pain_level, selected: last_log(:pain_logs, :pain_level), required: true, class: 'form-control' %>
       </div>
     </div>
   </div>
 
   <div class='field'>
     <%= form.label :trigger, class: 'required' %>
-    <%= form.text_area :trigger, class: 'form-control' %>
+    <%= form.text_area :trigger, required: true, class: 'form-control' %>
   </div>
 
   <div class='field'>
     <%= form.label 'Describe Pain', class: 'required' %>
-    <%= form.text_area :pain_description, class: 'form-control' %>
+    <%= form.text_area :pain_description, required: true, class: 'form-control' %>
   </div>
 
   <div class='actions mt-3 mb-3'>

--- a/app/views/pains/_form.html.erb
+++ b/app/views/pains/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field">
     <%= form.label :name, class: 'required' %>
-    <%= form.text_field :name, class: 'form-control' %>
+    <%= form.text_field :name, required: true, class: 'form-control' %>
   </div>
 
   <div class="actions mt-3 mb-3">

--- a/app/views/pt_sessions/_form.html.erb
+++ b/app/views/pt_sessions/_form.html.erb
@@ -4,8 +4,8 @@
   <div class='field'>
     <%= form.label 'Target Body Part', class: 'required' %>
     <%= form.collection_select :body_part_id,
-    current_user.body_parts, :id, :name,
     { include_blank: false },
+    current_user.body_parts.active, :id, :name,
     class: 'form-control' %>
   </div>
 

--- a/app/views/pt_sessions/_form.html.erb
+++ b/app/views/pt_sessions/_form.html.erb
@@ -4,19 +4,19 @@
   <div class='field'>
     <%= form.label 'Target Body Part', class: 'required' %>
     <%= form.collection_select :body_part_id,
-    { include_blank: false },
     current_user.body_parts.active, :id, :name,
+    { include_blank: false, required: true },
     class: 'form-control' %>
   </div>
 
   <div class='field'>
     <%= form.label 'When', class: 'required' %><br>
-    <%= form.datetime_select :datetime_occurred, ampm: true, minute_step: 15, value: Date.today, class: 'form-control' %>
+    <%= form.datetime_select :datetime_occurred, ampm: true, minute_step: 15, value: Date.today, required: true, class: 'form-control' %>
   </div>
 
   <div class='field'>
     <%= form.label :duration, class: 'required' %>
-    <%= form.number_field :duration, placeholder: 'minutes', class: 'form-control' %>
+    <%= form.number_field :duration, placeholder: 'minutes', required: true, class: 'form-control' %>
   </div>
 
   <div class='field'>
@@ -26,18 +26,19 @@
 
   <div class='field'>
     <%= form.label 'Session Notes', class: 'required' %>
-    <%= form.text_area :exercise_notes, class: 'form-control textarea-large' %>
+    <%= form.text_area :exercise_notes, required: true, class: 'form-control textarea-large' %>
   </div>
 
   <div class='field'>
     <%= form.label 'Homework Notes', class: 'required' %>
-    <%= form.text_area :homework, class: 'form-control textarea-large' %>
+    <%= form.text_area :homework, required: true, class: 'form-control textarea-large' %>
   </div>
 
   <div class='form-group row'>
     <div class='col-sm-12'>
-    <%= form.label 'Homework Exercises' %>
-
+      <div class='field'>
+        <%= form.label 'Homework Exercises' %>
+      </div>
     <%= form.collection_check_boxes :homework_exercise_ids, current_user.exercises.by_name, :id, :name do |exercise| %>
       <div class='form-check'>
         <%= exercise.check_box class: 'form-check-input' %>

--- a/db/migrate/20190601235732_add_active_to_body_parts.rb
+++ b/db/migrate/20190601235732_add_active_to_body_parts.rb
@@ -1,0 +1,5 @@
+class AddActiveToBodyParts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :body_parts, :archived, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_15_125542) do
+ActiveRecord::Schema.define(version: 2019_06_01_235732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_05_15_125542) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.boolean "archived", default: false
     t.index ["user_id"], name: "index_body_parts_on_user_id"
   end
 

--- a/spec/factories/body_parts.rb
+++ b/spec/factories/body_parts.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :body_part do
     user
     sequence(:name) { |n| "body_part#{n}" }
-    # active { true }
+    archived { false }
   end
 end

--- a/spec/factories/body_parts.rb
+++ b/spec/factories/body_parts.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :body_part do
     user
     sequence(:name) { |n| "body_part#{n}" }
+    # active { true }
   end
 end

--- a/spec/models/body_part_spec.rb
+++ b/spec/models/body_part_spec.rb
@@ -17,10 +17,18 @@ RSpec.describe BodyPart, type: :model do
 
   context 'attributes' do
     it 'should have all of its attributes' do
-      expected_attributes = %w[id user_id name created_at updated_at]
+      expected_attributes = %w[id
+                               archived
+                               name
+                               user_id
+                               created_at updated_at]
       actual_attributes = build(:body_part).attributes.keys
 
-      expect(expected_attributes).to match_array(actual_attributes)
+      expect(actual_attributes).to match_array(expected_attributes)
+    end
+  end
+
+
     end
   end
 

--- a/spec/models/body_part_spec.rb
+++ b/spec/models/body_part_spec.rb
@@ -28,7 +28,18 @@ RSpec.describe BodyPart, type: :model do
     end
   end
 
+  describe 'self.active' do
+    it 'returns a list of all non-archived body parts' do
+      active_body_part = create(:body_part, archived: false)
+      archived_body_part = create(:body_part, archived: true)
 
+      expect(BodyPart.active).to include(active_body_part)
+      expect(BodyPart.active).to_not include(archived_body_part)
+    end
+
+    it 'returns an empty array if there are no active body parts' do
+      create(:body_part, archived: true)
+      expect(BodyPart.active).to eq([])
     end
   end
 

--- a/spec/models/body_part_spec.rb
+++ b/spec/models/body_part_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe BodyPart, type: :model do
     it { should validate_uniqueness_of(:name).case_insensitive.scoped_to(:user_id) }
   end
 
+  context 'attributes' do
+    it 'should have all of its attributes' do
+      expected_attributes = %w[id user_id name created_at updated_at]
+      actual_attributes = build(:body_part).attributes.keys
+
+      expect(expected_attributes).to match_array(actual_attributes)
+    end
+  end
+
   describe 'self.by_name' do
     it 'returns a list of body_parts ordered by name, ascending' do
       body_part1 = create(:body_part, name: 'a')

--- a/spec/models/exercise_log_spec.rb
+++ b/spec/models/exercise_log_spec.rb
@@ -32,6 +32,29 @@ RSpec.describe ExerciseLog, type: :model do
     it { should delegate_method(:name).to(:exercise).with_prefix }
   end
 
+  context 'attributes' do
+    it 'should have all of its attributes' do
+      expected_attributes = %w[id
+                               body_part_id
+                               burn_rep
+                               burn_set
+                               datetime_occurred
+                               exercise_id
+                               per_side
+                               progress_note
+                               pt_session_id
+                               rep_length
+                               reps
+                               resistance
+                               sets
+                               user_id
+                               created_at updated_at]
+      actual_attributes = build(:exercise_log).attributes.keys
+
+      expect(expected_attributes).to match_array(actual_attributes)
+    end
+  end
+
   describe 'scopes' do
     describe 'at_home' do
       it 'returns exercise_logs that are not associated with a pt_session' do

--- a/spec/models/exercise_log_spec.rb
+++ b/spec/models/exercise_log_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ExerciseLog, type: :model do
                                created_at updated_at]
       actual_attributes = build(:exercise_log).attributes.keys
 
-      expect(expected_attributes).to match_array(actual_attributes)
+      expect(actual_attributes).to match_array(expected_attributes)
     end
   end
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Exercise, type: :model do
                                created_at updated_at]
       actual_attributes = build(:exercise).attributes.keys
 
-      expect(expected_attributes).to match_array(actual_attributes)
+      expect(actual_attributes).to match_array(expected_attributes)
     end
   end
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe Exercise, type: :model do
     it { should validate_presence_of(:default_rep_length) }
   end
 
+  context 'attributes' do
+    it 'should have all of its attributes' do
+      expected_attributes = %w[id
+                               default_per_side
+                               default_rep_length
+                               default_reps
+                               default_resistance
+                               default_sets
+                               description
+                               name
+                               user_id
+                               created_at updated_at]
+      actual_attributes = build(:exercise).attributes.keys
+
+      expect(expected_attributes).to match_array(actual_attributes)
+    end
+  end
+
   describe 'self.has_logs' do
     it 'returns all exercises that have logs' do
       exercise = create(:exercise, :with_3_exercise_logs)

--- a/spec/models/pain_log_spec.rb
+++ b/spec/models/pain_log_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PainLog, type: :model do
                                created_at updated_at]
       actual_attributes = build(:pain_log).attributes.keys
 
-      expect(expected_attributes).to match_array(actual_attributes)
+      expect(actual_attributes).to match_array(expected_attributes)
     end
   end
 

--- a/spec/models/pain_log_spec.rb
+++ b/spec/models/pain_log_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe PainLog, type: :model do
     it { should delegate_method(:name).to(:pain).with_prefix }
   end
 
+  context 'attributes' do
+    it 'should have all of its attributes' do
+      expected_attributes = %w[id
+                               body_part_id
+                               datetime_occurred
+                               pain_description
+                               pain_id
+                               pain_level
+                               trigger
+                               user_id
+                               created_at updated_at]
+      actual_attributes = build(:pain_log).attributes.keys
+
+      expect(expected_attributes).to match_array(actual_attributes)
+    end
+  end
+
   describe 'self.for_past_n_days' do
     it 'returns logs that occurred between today and the past n days' do
       pain_log = create(:pain_log, datetime_occurred: 2.days.ago)

--- a/spec/models/pain_spec.rb
+++ b/spec/models/pain_spec.rb
@@ -13,6 +13,18 @@ RSpec.describe Pain, type: :model do
     it { should validate_uniqueness_of(:name).case_insensitive.scoped_to(:user_id) }
   end
 
+  context 'attributes' do
+    it 'should have all of its attributes' do
+      expected_attributes = %w[id
+                               name
+                               user_id
+                               created_at updated_at]
+      actual_attributes = build(:pain).attributes.keys
+
+      expect(expected_attributes).to match_array(actual_attributes)
+    end
+  end
+
   describe 'self.has_logs' do
     it 'returns all pains that have logs' do
       pain = create(:pain, :with_3_pain_logs)

--- a/spec/models/pain_spec.rb
+++ b/spec/models/pain_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Pain, type: :model do
                                created_at updated_at]
       actual_attributes = build(:pain).attributes.keys
 
-      expect(expected_attributes).to match_array(actual_attributes)
+      expect(actual_attributes).to match_array(expected_attributes)
     end
   end
 

--- a/spec/models/pt_homework_exercise_spec.rb
+++ b/spec/models/pt_homework_exercise_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe PtHomeworkExercise, type: :model do
     it { should validate_presence_of(:pt_session) }
     it { should validate_presence_of(:exercise) }
   end
+
+  context 'attributes' do
+    it 'should have all of its attributes' do
+      expected_attributes = %w[id
+                               pt_session_id
+                               exercise_id
+                               created_at updated_at]
+      actual_attributes = build(:pt_homework_exercise).attributes.keys
+
+      expect(expected_attributes).to match_array(actual_attributes)
+    end
+  end
 end

--- a/spec/models/pt_homework_exercise_spec.rb
+++ b/spec/models/pt_homework_exercise_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PtHomeworkExercise, type: :model do
                                created_at updated_at]
       actual_attributes = build(:pt_homework_exercise).attributes.keys
 
-      expect(expected_attributes).to match_array(actual_attributes)
+      expect(actual_attributes).to match_array(expected_attributes)
     end
   end
 end

--- a/spec/models/pt_session_spec.rb
+++ b/spec/models/pt_session_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe PtSession, type: :model do
     it { should delegate_method(:name).to(:body_part).with_prefix }
   end
 
+  context 'attributes' do
+    it 'should have all of its attributes' do
+      expected_attributes = %w[id
+                               body_part_id
+                               datetime_occurred
+                               duration
+                               exercise_notes
+                               homework
+                               questions
+                               user_id
+                               created_at updated_at]
+      actual_attributes = build(:pt_session).attributes.keys
+
+      expect(expected_attributes).to match_array(actual_attributes)
+    end
+  end
+
   describe 'self.for_past_n_days' do
     it 'returns logs that occurred between today and the past n days' do
       pt_session = create(:pt_session, datetime_occurred: 2.days.ago)

--- a/spec/models/pt_session_spec.rb
+++ b/spec/models/pt_session_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PtSession, type: :model do
                                created_at updated_at]
       actual_attributes = build(:pt_session).attributes.keys
 
-      expect(expected_attributes).to match_array(actual_attributes)
+      expect(actual_attributes).to match_array(expected_attributes)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe User, type: :model do
     it { should have_many(:pt_sessions) }
   end
 
+  context 'attributes' do
+    it 'should have all of its attributes' do
+      expected_attributes = %w[id
+                               email
+                               encrypted_password
+                               reset_password_token
+                               reset_password_sent_at
+                               remember_created_at
+                               first_name
+                               last_name
+                               admin
+                               created_at updated_at]
+      actual_attributes = build(:user).attributes.keys
+
+      expect(expected_attributes).to match_array(actual_attributes)
+    end
+  end
+
   describe '#full_name' do
     it 'displays the users full name' do
       user = build(:user, first_name: 'first', last_name: 'last')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe User, type: :model do
                                created_at updated_at]
       actual_attributes = build(:user).attributes.keys
 
-      expect(expected_attributes).to match_array(actual_attributes)
+      expect(actual_attributes).to match_array(expected_attributes)
     end
   end
 


### PR DESCRIPTION
Closes #71 

## Problem
Sometimes a user has too many body parts in dropdowns for past injuries. It would be nice to make those go away without having to delete them.

## Solution
- Add an "archived" boolean to the body parts form
- limit the body parts that appear in dropdown to only "active" body parts

## Extra Girl Scout Work
- added html "required" attribute to required fields
- made form label styles prettier
- organized stylesheets 
- added better testing for expected attributes to model specs