### PR TITLE
53 rubocopping spike refactor

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -10,6 +10,6 @@ class ReportsController < ApplicationController
       body_part_id: params[:body_part_id]
     }
 
-    @report = Report.new(filter_params)
+    @report ||= Report.build_report(filter_params)
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ReportsController < ApplicationController
-  # layout 'no_white_container'
-
   def index
     filter_params = {
       user: current_user,
@@ -10,6 +8,6 @@ class ReportsController < ApplicationController
       body_part_id: params[:body_part_id]
     }
 
-    @report ||= Report.build_report(filter_params)
+    @report = Report.new(filter_params)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,24 +4,44 @@ class Report
   attr_reader :exercise_logs, :pain_logs, :pt_sessions, :pains, :exercises, :body_parts
 
   def initialize(args)
-    @filter_params = args
-    @exercise_logs ||= query_logs('exercise_logs')
-    @pain_logs ||= query_logs('pain_logs')
-    @pt_sessions ||= query_logs('pt_sessions')
-    @pains ||= @filter_params[:user].pains
-    @exercises ||= @filter_params[:user].exercises
-    @body_parts ||= @filter_params[:user].body_parts
+    @exercise_logs = args[:exercise_logs]
+    @pain_logs = args[:pain_logs]
+    @pt_sessions = args[:pt_sessions]
+    @pains = args[:pains]
+    @exercises = args[:exercises]
+    @body_parts = args[:body_parts]
   end
 
-  private
+  class << self
+    def build_report(filter_params) # rubocop:disable Metrics/MethodLength
+      @filter_params = filter_params
+      exercise_logs = query_logs('exercise_logs')
+      pain_logs = query_logs('pain_logs')
+      pt_sessions = query_logs('pt_sessions')
+      pains = filter_params[:user].pains
+      exercises = filter_params[:user].exercises
+      body_parts = filter_params[:user].body_parts
 
-  def query_logs(log_type)
-    logs = log_type.classify
-                   .constantize
-                   .where(user_id: @filter_params[:user].id)
+      Report.new(
+        exercise_logs: exercise_logs,
+        pain_logs: pain_logs,
+        pt_sessions: pt_sessions,
+        pains: pains,
+        exercises: exercises,
+        body_parts: body_parts
+      )
+    end
 
-    logs = logs.for_body_part(@filter_params[:body_part_id]) if @filter_params[:body_part_id].present?
-    logs = logs.for_past_n_days(@filter_params[:timeframe].to_i) if @filter_params[:timeframe].present?
-    logs
+    private
+
+    def query_logs(log_type)
+      logs = log_type.classify
+                     .constantize
+                     .where(user_id: @filter_params[:user].id)
+
+      logs = logs.for_body_part(@filter_params[:body_part_id]) if @filter_params[:body_part_id].present?
+      logs = logs.for_past_n_days(@filter_params[:timeframe].to_i) if @filter_params[:timeframe].present?
+      logs
+    end
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,47 +1,43 @@
 # frozen_string_literal: true
 
 class Report
-  attr_reader :exercise_logs, :pain_logs, :pt_sessions, :pains, :exercises, :body_parts
+  attr_reader :filter_params
 
-  def initialize(args)
-    @exercise_logs = args[:exercise_logs]
-    @pain_logs = args[:pain_logs]
-    @pt_sessions = args[:pt_sessions]
-    @pains = args[:pains]
-    @exercises = args[:exercises]
-    @body_parts = args[:body_parts]
+  def initialize(filter_params)
+    @filter_params = filter_params
   end
 
-  class << self
-    def build_report(filter_params) # rubocop:disable Metrics/MethodLength
-      @filter_params = filter_params
-      exercise_logs = query_logs('exercise_logs')
-      pain_logs = query_logs('pain_logs')
-      pt_sessions = query_logs('pt_sessions')
-      pains = filter_params[:user].pains
-      exercises = filter_params[:user].exercises
-      body_parts = filter_params[:user].body_parts
+  def exercise_logs
+    @exercise_logs ||= query_logs(ExerciseLog)
+  end
 
-      Report.new(
-        exercise_logs: exercise_logs,
-        pain_logs: pain_logs,
-        pt_sessions: pt_sessions,
-        pains: pains,
-        exercises: exercises,
-        body_parts: body_parts
-      )
-    end
+  def pain_logs
+    @pain_logs ||= query_logs(PainLog)
+  end
 
-    private
+  def pt_sessions
+    @pt_sessions ||= query_logs(PtSession)
+  end
 
-    def query_logs(log_type)
-      logs = log_type.classify
-                     .constantize
-                     .where(user_id: @filter_params[:user].id)
+  def pains
+    @pains ||= filter_params[:user].pains
+  end
 
-      logs = logs.for_body_part(@filter_params[:body_part_id]) if @filter_params[:body_part_id].present?
-      logs = logs.for_past_n_days(@filter_params[:timeframe].to_i) if @filter_params[:timeframe].present?
-      logs
-    end
+  def exercises
+    @exercises ||= filter_params[:user].exercises
+  end
+
+  def body_parts
+    @body_parts ||= filter_params[:user].body_parts
+  end
+
+  private
+
+  def query_logs(log_type)
+    logs = log_type.where(user_id: @filter_params[:user].id)
+
+    logs = logs.for_body_part(@filter_params[:body_part_id]) if @filter_params[:body_part_id].present?
+    logs = logs.for_past_n_days(@filter_params[:timeframe].to_i) if @filter_params[:timeframe].present?
+    logs
   end
 end


### PR DESCRIPTION
Trying to resolve this complexity error.

Rubocop said my initialize was too complex. It was, so I moved it out into another method. That method now has too many lines. I'm not worried about that.

I would like to reduce the querying made by the `reports` page. This is why I memoized the `@report` instance variable. But now Rubocop says memoizing isn't cool and that `@report` should be `@index`. This is crazytalk, Rubocop. 