### PR TITLE
Convert conditional to case statement

### DIFF
--- a/app/models/occurrence_calculator.rb
+++ b/app/models/occurrence_calculator.rb
@@ -27,22 +27,24 @@ class OccurrenceCalculator
   # rubocop:disable Metrics/MethodLength
   def timeframe
     seconds = last_datetime - first_datetime
-    days = (seconds / 60 / 60 / 24)
+    days_between_first_and_last = (seconds / 60 / 60 / 24)
     data = OpenStruct.new
-    if days.zero?
+
+    case days_between_first_and_last
+    when 0
       data.qty = 1.round(1)
       data.unit = 'day'
-    elsif days < 7
-      data.qty = days.round(1)
+    when 1..6
+      data.qty = days_between_first_and_last.round(1)
       data.unit = 'day'
-    elsif days < 30
-      data.qty = (days / 7).round(1)
+    when 7..29
+      data.qty = (days_between_first_and_last / 7).round(1)
       data.unit = 'week'
-    elsif days < 360
-      data.qty = (days / 30).round(1)
+    when 30..360
+      data.qty = (days_between_first_and_last / 30).round(1)
       data.unit = 'month'
     else
-      data.qty = (days / 360).round(1)
+      data.qty = (days_between_first_and_last / 360).round(1)
       data.unit = 'year'
     end
     data

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -15,7 +15,7 @@
       History
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-      <%= link_to 'Stats by Body Part', stats_path, class: 'dropdown-item' %>
+      <%= link_to 'Pain Stats by Body Part', stats_path, class: 'dropdown-item' %>
       <%= link_to 'Charts', charts_path, class: 'dropdown-item' %>
       <%= link_to 'Exercise Logs', exercise_logs_path, class: 'dropdown-item' %>
       <%= link_to 'Pain Logs', pain_logs_path, class: 'dropdown-item' %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Stats by Body Part</h1>
+<h1>Pain Stats by Body Part</h1>
 <%= render partial: 'shared/filter_form', locals: { destination_path: stats_path, body_parts: @report.body_parts } %>
 
 <% @report.pain_stats_by_body_part.each do |body_part, pain_logs| %>


### PR DESCRIPTION
## Problems Solved
The multi-part `if` statement I was using in the method to calculate timeframe for pain data was clunky. After pairing with @flylady2, we chose to convert it to a case statement. In the process, we also renamed a variable and now the method is much easier to read. 🙌 

While I was working on this page, I also clarified the heading and nav bar item by adding the word "pain".
