### PR TITLE
Add commented out config for future

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,7 @@ module TherapyTracker
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.active_support.cache_format_version = 7.0
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,7 +9,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '82b7f54137243ed3b04c2d6781218eee9c27e6b046da00dca25c835ac1bfacefb919e622c66a8b207bb7172cb7903327fd0434095532b089dffb6edcee816476'
-  
+
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'
@@ -287,4 +287,21 @@ Devise.setup do |config|
   # ActiveSupport.on_load(:devise_failure_app) do
   #   include Turbolinks::Controller
   # end
+
+  # ## Hotwire / Turbo Integration ##
+  # https://github.com/heartcombo/devise/wiki/How-To:-Upgrade-to-Devise-4.9.0-%5BHotwire-Turbo-integration%5D
+  # For better Hotwire / Turbo integration and these new defaults, Devise requires the
+  # latest `Responders` gem version (v3.1.0 or higher), which allows configuring the status used
+  # for validation error responses (error_status) and for redirects after POST/PUT/PATCH/DELETE
+  # requests (redirect_status).
+  # For backwards compatibility, Devise is configured internally with error_status as :ok (200 OK), and
+  # redirect_status as :found (302 Found). Configuring it like above would set the error and redirect
+  # statuses to 422 Unprocessable Entity and 303 See Other respectively, to match the behavior
+  # expected by Hotwire/Turbo.
+  # Trying to set these configs on the latest Devise but with an older version of Responders
+  # that does not support them, will issue a warning and have no effect.
+  # Note: these defaults may change in future versions of Devise, to better match the Rails + Hotwire/Turbo
+  # defaults across the board.
+  # config.responder.error_status = :unprocessable_entity
+  # config.responder.redirect_status = :see_other
 end


### PR DESCRIPTION
As I've done other rails 7 upgrades, I've found some settings that will be needed in this repo soon. Instead of searching for themthen, I'm putting them in place -- commented out -- so that I'll know what to do when the time comes. While this usually goes against YAGNI, in this case, I want to do it because config is not my jam and this helps FutureMe.

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
- [ ] If this work contains migrations, I have run them in prod