### PR TITLE
Separate regular slit logging from quick logging

### DIFF
--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -21,10 +21,17 @@ class SlitLogsController < ApplicationController
   end
 
   def create
-    @slit_log = current_user.slit_logs.new(
-      datetime_occurred: params[:datetime_occurred] || Time.current,
-      started_new_bottle: params[:started_new_bottle]
-    )
+    @slit_log = current_user.slit_logs.new(slit_log_params)
+
+    if @slit_log.save!
+      redirect_to root_url
+    else
+      render :new
+    end
+  end
+
+  def quick_log_create
+    @slit_log = current_user.slit_logs.new(datetime_occurred: Time.current)
 
     if @slit_log.save!
       redirect_to root_url

--- a/app/views/buttons/_new_slit_log.html.erb
+++ b/app/views/buttons/_new_slit_log.html.erb
@@ -1,1 +1,1 @@
-<%= link_to '<span class="material-symbols-outlined">colorize</span><br>+SLIT'.html_safe, slit_logs_path, method: :post, class: 'add-log-button slit-button' %>
+<%= link_to '<span class="material-symbols-outlined">colorize</span><br>+SLIT'.html_safe, quick_log_create_path, method: :post, class: 'add-log-button slit-button' %>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -17,7 +17,7 @@
       Quick Log
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-      <%= link_to 'SLIT dose', slit_logs_path, method: :post, class: 'dropdown-item'  %>
+      <%= link_to 'SLIT dose', quick_log_create_path, method: :post, class: 'dropdown-item'  %>
       <% current_user.pain_log_quick_form_values.order(name: :asc).each do |attr| %>
         <%= link_to attr.name, create_pain_log_from_quick_form_path(content: attr), method: :post, class: 'dropdown-item'  %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,5 @@ Rails.application.routes.draw do
   end
 
   resources :slit_logs
+  post '/quick_log_create', to: 'slit_logs#quick_log_create'
 end

--- a/spec/requests/slit_logs_spec.rb
+++ b/spec/requests/slit_logs_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe SlitLogsController, type: :request do
       expect(response).to redirect_to new_user_session_path
     end
 
+    it 'denies access to slit_logs#quick_log_create' do
+      expect {
+        post quick_log_create_path
+      }.to_not change(SlitLog, :count)
+
+      expect(response).to redirect_to new_user_session_path
+    end
+
     it 'denies access to slit_logs#update' do
       patch slit_log_path(slit_log, slit_log: slit_log.attributes)
       expect(response).to redirect_to new_user_session_path
@@ -55,10 +63,24 @@ RSpec.describe SlitLogsController, type: :request do
     end
 
     it 'renders slit_logs#create' do
-      slit_log_attributes = build(:slit_log, user_id: user.id).attributes
+      slit_log_attributes = build(
+        :slit_log,
+        user_id: user.id,
+        datetime_occurred: Time.current,
+        started_new_bottle: true,
+        doses_remaining: 5
+      ).attributes
 
       expect {
         post slit_logs_path(slit_log: slit_log_attributes)
+      }.to change(SlitLog, :count)
+
+      expect(response).to redirect_to root_url
+    end
+
+    it 'renders slit_logs#quick_log_create' do
+      expect {
+        post quick_log_create_path
       }.to change(SlitLog, :count)
 
       expect(response).to redirect_to root_url


### PR DESCRIPTION
## Problems Solved
* There was a params problem where quick logging worked just fine, but adding from a new form (via traditional new/create) was not picking up the controller values. 
* this pr fixes that bug and adds specs for the new controller action

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
