### PR TITLE
Make basic print view to take to dr

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -7,6 +7,7 @@ $light-gray: #f1f1f1;
 $medium-gray: #ccc;
 $error: ff0000;
 $white: #fff;
+$black: #000;
 
 $pain-color: #f2b134;
 $exercise-color: #48aa6c;

--- a/app/assets/stylesheets/slit.scss
+++ b/app/assets/stylesheets/slit.scss
@@ -1,3 +1,5 @@
+@import 'variables';
+
 // https://developer.mozilla.org/en-US/docs/Web/CSS/columns#try_it
 .slit-report-data-container {
   columns: 3 auto;

--- a/app/assets/stylesheets/slit.scss
+++ b/app/assets/stylesheets/slit.scss
@@ -4,18 +4,18 @@
 }
 
 .slit-report-data-row {
-  display: flex;
   align-items: center;
+  border-bottom: 1px solid $black;
+  border-left: 1px solid $black;
+  border-right: 1px solid $black;
+  display: flex;
   gap: 1rem;
   padding: .5rem;
-  border-bottom: 1px solid black;
-  border-left: 1px solid black;
-  border-right: 1px solid black;
 }
 
 .slit-report-data-header {
+  border: 1px solid $black;
   font-weight: bold;
-  border: 1px solid black;
 }
 
 .slit-report-col-dose {
@@ -27,7 +27,9 @@
   .slit-report-data-container {
     columns: auto;
   }
-  .slit-report-data-header:nth-of-type(2), .slit-report-data-header:nth-of-type(3) {
+
+  .slit-report-data-header:nth-of-type(2),
+  .slit-report-data-header:nth-of-type(3) {
     display: none;
   }
 }

--- a/app/assets/stylesheets/slit.scss
+++ b/app/assets/stylesheets/slit.scss
@@ -1,0 +1,35 @@
+// https://developer.mozilla.org/en-US/docs/Web/CSS/columns#try_it
+.slit-report-data-container {
+  columns: 3 auto;
+}
+
+.slit-report-data-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: .5rem;
+  border-bottom: 1px solid black;
+  border-left: 1px solid black;
+  border-right: 1px solid black;
+}
+
+.slit-report-data-header {
+  font-weight: bold;
+  border: 1px solid black;
+}
+
+.slit-report-col-dose {
+  width: 3rem;
+}
+
+// MEDIA QUERIES
+@media (max-width: 576px) {
+  .slit-report-data-container {
+    columns: auto;
+  }
+  .slit-report-data-header:nth-of-type(2), .slit-report-data-header:nth-of-type(3) {
+    display: none;
+  }
+}
+
+

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -57,6 +57,10 @@ class SlitLogsController < ApplicationController
     end
   end
 
+  def report
+    @logs = current_user.slit_logs.where(datetime_occurred: 90.days.ago..Time.current).order(datetime_occurred: :asc)
+  end
+
   private
 
   def set_slit_log

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -58,7 +58,11 @@ class SlitLogsController < ApplicationController
   end
 
   def report
-    @logs = current_user.slit_logs.where(datetime_occurred: 90.days.ago..Time.current).order(datetime_occurred: :asc)
+    report_record_limit = 90
+    @logs = current_user.slit_logs
+                        .where(datetime_occurred: report_record_limit.days.ago..Time.current)
+                        .order(datetime_occurred: :asc)
+                        .limit(report_record_limit)
   end
 
   private

--- a/app/views/slit_logs/report.html.erb
+++ b/app/views/slit_logs/report.html.erb
@@ -1,0 +1,26 @@
+<h1>Sublingual Immunotherapy Patient Documentation<br>Mantenance Dosage</h1>
+<h2>Call 336-659-4814 to order more drops</h2>
+<p>For <%= current_user.email %> from <%= @logs.first.datetime_occurred.strftime('%m/%d/%y') %> to <%= @logs.last.datetime_occurred.strftime('%m/%d/%y') %></p>
+<p><strong>NB</strong> = started new bottle</p>
+
+<div class='slit-report-data-container mt-4'>
+  <% 3.times do %>
+    <div class="slit-report-data-row slit-report-data-header">
+      <span class='row-col-dose'>Dose</span>
+      <span>Taken</span>
+    </div>
+  <% end %>
+</div>
+
+<div class='slit-report-data-container'>
+  <% @logs.each_with_index do |log, index| %>
+    <div class="slit-report-data-row">
+      <span class='slit-report-col-dose'><%= index + 1 %></span>
+      <span><%= log.datetime_occurred.strftime('%m/%d/%y at %I:%M%p') %></span>
+      <% if log.started_new_bottle? %>
+        <span><strong>NB</strong></span>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,4 +28,5 @@ Rails.application.routes.draw do
 
   resources :slit_logs
   post '/quick_log_create', to: 'slit_logs#quick_log_create'
+  get '/slit_report', to: 'slit_logs#report'
 end


### PR DESCRIPTION
## Related Issues & PRs
Closes #759

## Scope includes
* basic table-looking printout view that mimics the paper table provided for manual logging
* prints in 3 columns
* includes "new bottle" indication
* mobile styles
* prints all records for the past 90 days (a typical SLIT feedback window)
* doing a cmd +p from the browser lets you print the data in a printer-friendly way

## Scope does not include
* displaying "skipped" doses in the printout
* allowing for dynamic reporting between user-provided dates

## Screenshots
<img width="1176" alt="Screenshot 2024-03-10 at 3 23 23 PM" src="https://github.com/lortza/therapy_tracker/assets/8680712/ca728474-e080-4e79-8186-cbffa3da9cf3">

## Things Learned
* css `columns` is a really handy way to make content from through columns like a newspaper layout 


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
- [x] If this work contains migrations, I have run them in prod