### PR TITLE
Add prod procfile with migrations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+release: rails db:migrate


### PR DESCRIPTION
## Problems Solved
* Adds a production Procfile that has been missing
* Adds migrations to the heroku release phase

## Things Learned
* Heroku has a release phase that allows you to run commands after merge and before deploy https://mentalized.net/journal/2017/04/22/run-rails-migrations-on-heroku-deploy/
* Heroku docs https://devcenter.heroku.com/articles/release-phase

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
- [x] If this work contains migrations, I have run them in prod