### PR TITLE
Add SLIT therapy back end logic and display logic for "skipped" doses 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,4 +15,3 @@ Closes #X
 - [ ] I have written new specs for this work
 - [ ] I have browser tested this work
 - [ ] I have deployed the feature branch to production and browser tested it successfully
-- [ ] If this work contains migrations, I have run them in prod

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -14,6 +14,6 @@ $exercise-color: #48aa6c;
 $therapy-color: #0994a1;
 $slit-color: #8228d5;
 
-$red:  #C70039  ;
+$red:#c70039;
 $orange: #ed553b;
 $dk-blue: #112f41;

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -14,5 +14,6 @@ $exercise-color: #48aa6c;
 $therapy-color: #0994a1;
 $slit-color: #8228d5;
 
+$red:  #C70039  ;
 $orange: #ed553b;
 $dk-blue: #112f41;

--- a/app/assets/stylesheets/logs.scss
+++ b/app/assets/stylesheets/logs.scss
@@ -21,6 +21,8 @@
   font-size: .8rem;
 }
 
+.log-icon-color {color: $black;}
+
 .card-title {
   font-size: 1rem;
   margin-bottom: .5rem;
@@ -31,8 +33,10 @@
   line-height: 1rem;
 }
 
+.dose-skipped { color: $red; }
+
 @mixin log-type-color($color) {
-  .log-icon { color: $color; }
+  .log-icon-color { color: $color; }
   .card-title { color: $color; }
 }
 

--- a/app/views/exercise_logs/_exercise_log_header.html.erb
+++ b/app/views/exercise_logs/_exercise_log_header.html.erb
@@ -1,4 +1,4 @@
 <header class='log-type-exercise'>
-  <span class='log-icon'>Exercise <i class='fal fa-dumbbell'></i></span>
+  <span class='log-icon log-icon-color'>Exercise <i class='fal fa-dumbbell'></i></span>
   <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
 </header>

--- a/app/views/pain_logs/_pain_log_header.html.erb
+++ b/app/views/pain_logs/_pain_log_header.html.erb
@@ -1,4 +1,4 @@
 <header class='log-type-pain'>
-  <span class='log-icon'>Pain <i class='fal fa-user-injured'></i></span>
+  <span class='log-icon log-icon-color'>Pain <i class='fal fa-user-injured'></i></span>
   <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
 </header>

--- a/app/views/pt_session_logs/_pt_session_log_header.html.erb
+++ b/app/views/pt_session_logs/_pt_session_log_header.html.erb
@@ -1,4 +1,4 @@
 <header class='log-type-therapy'>
-  <span class='log-icon'>PT Session <i class='fal fa-hospital-user'></i></span>
+  <span class='log-icon log-icon-color'>PT Session <i class='fal fa-hospital-user'></i></span>
   <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
 </header>

--- a/app/views/slit_logs/_slit_log.html.erb
+++ b/app/views/slit_logs/_slit_log.html.erb
@@ -1,10 +1,14 @@
 <div class="card card--log-entry log-border-slit">
   <a href="<%= edit_slit_log_path(slit_log) %>">
     <div class="card-body">
-      <%= render partial: 'slit_logs/slit_log_header', locals: { log: slit_log } %>
+      <% if slit_log.dose_skipped? %>
+        <%= render partial: 'slit_logs/slit_log_skipped_dose_header', locals: { log: slit_log } %>
+      <% else %>
+        <%= render partial: 'slit_logs/slit_log_header', locals: { log: slit_log } %>
+      <% end %>
 
       <p class="card-text">
-        Took drops
+        <%= slit_log.dose_skipped? ? 'Skipped Dose' : 'Took drops' %>
         <%= " | #{slit_log.doses_remaining} doses remaining" if slit_log.doses_remaining.present? %>
         <%= ' (Started new bottle)' if slit_log.started_new_bottle? %>
       </p>

--- a/app/views/slit_logs/_slit_log_header.html.erb
+++ b/app/views/slit_logs/_slit_log_header.html.erb
@@ -1,4 +1,4 @@
 <header class='log-type-slit'>
-  <span class='log-icon'>SLIT <span class="material-symbols-outlined">colorize</span></span>
+  <span class='log-icon log-icon-color'>SLIT Dose <span class="material-symbols-outlined">colorize</span></span>
   <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
 </header>

--- a/app/views/slit_logs/_slit_log_skipped_dose_header.html.erb
+++ b/app/views/slit_logs/_slit_log_skipped_dose_header.html.erb
@@ -1,0 +1,4 @@
+<header class='log-type-slit'>
+  <span class='log-icon dose-skipped'>SLIT Dose Skipped <span class="material-symbols-outlined">warning</span></span>
+  <h5 class='card-title'><%= "#{log.occurred_at.strftime('%a %m/%d/%y')} missing" if log.persisted? %></h5>
+</header>

--- a/app/views/slit_logs/report.html.erb
+++ b/app/views/slit_logs/report.html.erb
@@ -1,7 +1,10 @@
 <h1>Sublingual Immunotherapy Patient Documentation<br>Mantenance Dosage</h1>
 <h2>Call 336-659-4814 to order more drops</h2>
 <p>For <%= current_user.email %> from <%= @logs.first.occurred_at.strftime('%m/%d/%y') %> to <%= @logs.last.occurred_at.strftime('%m/%d/%y') %></p>
-<p><strong>NB</strong> = started new bottle</p>
+<p>
+  <strong>NB</strong> = started new bottle<br>
+  <strong>SKIPPED</strong> = drops not taken for date
+</p>
 
 <div class='slit-report-data-container mt-4'>
   <% 3.times do %>
@@ -16,7 +19,12 @@
   <% @logs.each_with_index do |log, index| %>
     <div class="slit-report-data-row">
       <span class='slit-report-col-dose'><%= index + 1 %></span>
-      <span><%= log.occurred_at.strftime('%m/%d/%y at %I:%M%p') %></span>
+      <% if log.dose_skipped? %>
+        <span><%= log.occurred_at.strftime('%m/%d/%y') %> <strong>SKIPPED</strong></span>
+      <% else %>
+        <span><%= log.occurred_at.strftime('%m/%d/%y at %I:%M%p') %></span>
+      <% end %>
+
       <% if log.started_new_bottle? %>
         <span><strong>NB</strong></span>
       <% end %>

--- a/db/migrate/20240317143500_add_dose_skipped_to_slit_logs.rb
+++ b/db/migrate/20240317143500_add_dose_skipped_to_slit_logs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDoseSkippedToSlitLogs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :slit_logs, :dose_skipped, :boolean, default: :false
+  end
+end

--- a/db/migrate/20240317151929_add_enable_slit_tracking_to_user.rb
+++ b/db/migrate/20240317151929_add_enable_slit_tracking_to_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEnableSlitTrackingToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :enable_slit_tracking, :boolean, default: :false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_16_214955) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_17_151929) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -158,6 +158,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_16_214955) do
     t.integer "doses_remaining"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "dose_skipped"
     t.index ["occurred_at"], name: "index_slit_logs_on_occurred_at"
     t.index ["user_id"], name: "index_slit_logs_on_user_id"
   end
@@ -173,6 +174,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_16_214955) do
     t.boolean "admin", default: false, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "enable_slit_tracking", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/slit_logs.rb
+++ b/spec/factories/slit_logs.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     occurred_at { nil }
     started_new_bottle { false }
     doses_remaining { nil }
+    dose_skipped { false }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     sequence(:email) { |n| "user#{n}@example.com" }
     password { 'password' }
     password_confirmation { 'password' }
+    enable_slit_tracking { false }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe User, type: :model do
                                first_name
                                last_name
                                admin
+                               enable_slit_tracking
                                created_at updated_at]
       actual_attributes = build(:user).attributes.keys
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #769
Related to #768
Related to #762

## Problems Solved
* adds skipped column to `slit_logs` table
* adds front end conditional logic to display a day when doses were skipped
    * logs index views
    * slit printout view
* adds table change for #786

## Screenshots
<img width="1119" alt="Screenshot 2024-03-17 at 2 02 20 PM" src="https://github.com/lortza/therapy_tracker/assets/8680712/194989b0-e38d-4fb1-9a9d-dfe7523ae15a">
<img width="1209" alt="Screenshot 2024-03-17 at 2 02 57 PM" src="https://github.com/lortza/therapy_tracker/assets/8680712/7243d105-5087-4f02-b593-4dedd5060f80">

## Things learned
* I needed to separate the css concerns of color from styling into different classes in order to be more clean about style rendering and to avoid collisions

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully