### PR TITLE
Service for logging yesterday's skipped doses

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -14,6 +14,6 @@ $exercise-color: #48aa6c;
 $therapy-color: #0994a1;
 $slit-color: #8228d5;
 
-$red:#c70039;
+$red: #c70039;
 $orange: #ed553b;
 $dk-blue: #112f41;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,6 @@ class User < ApplicationRecord
 
   scope :with_slit_enabled, -> { where(enable_slit_tracking: true) }
 
-
   def full_name
     "#{first_name} #{last_name}"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,9 @@ class User < ApplicationRecord
   has_many :pt_session_logs, dependent: :destroy
   has_many :slit_logs, dependent: :destroy
 
+  scope :with_slit_enabled, -> { where(enable_slit_tracking: true) }
+
+
   def full_name
     "#{first_name} #{last_name}"
   end

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SlitLogSkippedDoseService
+  def self.call
+    User.with_slit_enabled.each do |user|
+      last_log = user.slit_logs.order(occurred_at: :desc).limit(1).first
+      if last_log.nil? || last_log.occurred_at.to_date != Date.yesterday
+        user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
+      else
+        next
+      end
+    end
+  end
+end

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -4,11 +4,9 @@ class SlitLogSkippedDoseService
   def self.call
     User.with_slit_enabled.each do |user|
       last_log = user.slit_logs.order(occurred_at: :desc).limit(1).first
-      if last_log.nil? || last_log.occurred_at.to_date != Date.yesterday
-        user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
-      else
-        next
-      end
+      next unless last_log.nil? || (last_log.occurred_at.to_date != Date.yesterday)
+
+      user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
     end
   end
 end

--- a/lib/tasks/heroku_cron_tasks.rake
+++ b/lib/tasks/heroku_cron_tasks.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :heroku_cron do
+  namespace :slit_logs do
+    desc 'Create Skipped Dose'
+    task create_skipped_dose: :environment do
+      # rake heroku_cron:slit_logs:create_skipped_dose
+
+      # Heroku runs this daily at 6am UTC / 2am EST: https://dashboard.heroku.com/apps/therapytracker/scheduler
+      # UTC is 4 hours ahead of Eastern Time: https://savvytime.com/converter/utc-to-est
+      SlitLogSkippedDoseService.call
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'scopes' do
+    describe 'with_slit_enabled' do
+      let(:user_with_slit_tracking) { create(:user, enable_slit_tracking: true) }
+      let(:user_without_slit_tracking) { create(:user, enable_slit_tracking: false) }
+
+      before do
+        user_with_slit_tracking
+        user_without_slit_tracking
+      end
+
+      it 'includes users with slit_tracking_enabled' do
+        expect(described_class.with_slit_enabled).to include(user_with_slit_tracking)
+      end
+
+      it 'excludes users without slit_tracking_enabled' do
+        expect(described_class.with_slit_enabled).not_to include(user_without_slit_tracking)
+      end
+    end
+  end
+
   describe '#full_name' do
     it 'displays the users full name' do
       user = build(:user, first_name: 'first', last_name: 'last')

--- a/spec/services/slit_log_skipped_dose_service_spec.rb
+++ b/spec/services/slit_log_skipped_dose_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SlitLogSkippedDoseService, type: :service do
       let(:user) { create(:user, enable_slit_tracking: false) }
 
       it 'does not create a skip log' do
-        expect { service }.not_to change { SlitLog.count }
+        expect { service }.not_to(change { SlitLog.count })
         user.slit_logs.create!(occurred_at: yesterday_datetime - 1.day)
       end
     end
@@ -60,14 +60,14 @@ RSpec.describe SlitLogSkippedDoseService, type: :service do
 
       context 'and has no slit_logs' do
         it 'creates a skip log' do
-          expect { service }.to change { user.slit_logs.count }
+          expect { service }.to(change { user.slit_logs.count })
         end
       end
 
       context 'and logged a dose yesterday' do
         it 'does not create a skip log' do
           user.slit_logs.create(occurred_at: yesterday_datetime)
-          expect { service }.not_to change { user.slit_logs.count }
+          expect { service }.not_to(change { user.slit_logs.count })
         end
       end
 
@@ -97,7 +97,7 @@ RSpec.describe SlitLogSkippedDoseService, type: :service do
       context "and yesterday's log is for a skipped dose" do
         it 'does not create another skipped dose log for yesterday' do
           user.slit_logs.create!(occurred_at: yesterday_datetime, dose_skipped: true)
-          expect { service }.not_to change { user.slit_logs.count }
+          expect { service }.not_to(change { user.slit_logs.count })
         end
       end
     end

--- a/spec/services/slit_log_skipped_dose_service_spec.rb
+++ b/spec/services/slit_log_skipped_dose_service_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SlitLogSkippedDoseService, type: :service do
+  let(:service) { described_class.call }
+  describe 'self.call' do
+    let(:user) { create(:user) }
+    let(:yesterday_date) { Date.parse('2024-03-01') }
+    let(:yesterday_datetime) { DateTime.parse('2024-03-01') }
+    let(:today_date) { Date.parse('2024-03-02') }
+
+    before do
+      allow(Date).to receive(:yesterday).and_return(yesterday_date)
+      allow(DateTime).to receive(:yesterday).and_return(yesterday_datetime)
+      allow(Date).to receive(:today).and_return(today_date)
+    end
+
+    context 'when there are multiple users of the app' do
+      it 'calculates skips in context to the user' do
+        user_who_skipped = create(:user, enable_slit_tracking: true)
+
+        user_who_took_dose = create(:user, enable_slit_tracking: true)
+        user_who_took_dose.slit_logs.create(occurred_at: yesterday_datetime)
+
+        service
+        aggregate_failures do
+          expect(user_who_skipped.slit_logs.last.dose_skipped?).to eq(true)
+          expect(user_who_took_dose.slit_logs.last.dose_skipped?).to eq(false)
+          expect(user_who_skipped.slit_logs.count).to eq(1)
+          expect(user_who_took_dose.slit_logs.count).to eq(1)
+        end
+      end
+
+      it 'creates a skip log for all users who have SLIT tracking enabled and skipped a dose' do
+        user_who_skipped = create(:user, enable_slit_tracking: true)
+        other_user_who_skipped = create(:user, enable_slit_tracking: true)
+
+        service
+        aggregate_failures do
+          expect(user_who_skipped.slit_logs.last.dose_skipped?).to eq(true)
+          expect(other_user_who_skipped.slit_logs.last.dose_skipped?).to eq(true)
+          expect(user_who_skipped.slit_logs.count).to eq(1)
+          expect(other_user_who_skipped.slit_logs.count).to eq(1)
+        end
+      end
+    end
+
+    context 'when the user is not on SLIT therapy' do
+      let(:user) { create(:user, enable_slit_tracking: false) }
+
+      it 'does not create a skip log' do
+        expect { service }.not_to change { SlitLog.count }
+        user.slit_logs.create!(occurred_at: yesterday_datetime - 1.day)
+      end
+    end
+
+    context 'when a user is on SLIT therapy' do
+      let(:user) { create(:user, enable_slit_tracking: true) }
+
+      context 'and has no slit_logs' do
+        it 'creates a skip log' do
+          expect { service }.to change { user.slit_logs.count }
+        end
+      end
+
+      context 'and logged a dose yesterday' do
+        it 'does not create a skip log' do
+          user.slit_logs.create(occurred_at: yesterday_datetime)
+          expect { service }.not_to change { user.slit_logs.count }
+        end
+      end
+
+      context 'and did not log a dose yesterday' do
+        before do
+          user.slit_logs.create!(occurred_at: yesterday_datetime - 1)
+        end
+
+        it 'creates a log' do
+          expect { service }.to change { SlitLog.count }.by(1)
+        end
+
+        it "creates a log with yesterday's date" do
+          service
+          user.slit_logs.reload
+          last_log = user.slit_logs.order(occurred_at: :desc).first
+          expect(last_log.occurred_at).to eq(yesterday_datetime)
+        end
+
+        it "creates a log with yesterday's date and dose_skipped: true" do
+          service
+          last_log = user.slit_logs.order(occurred_at: :desc).first
+          expect(last_log.dose_skipped).to eq(true)
+        end
+      end
+
+      context "and yesterday's log is for a skipped dose" do
+        it 'does not create another skipped dose log for yesterday' do
+          user.slit_logs.create!(occurred_at: yesterday_datetime, dose_skipped: true)
+          expect { service }.not_to change { user.slit_logs.count }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
Closes #771
Closes #762

## Problems Solved
* When a user skips a SLIT dose, the app populates a "skip" log for them. 
* Users can see doses they've skipped in the views
* Skipped doses appear in the dr printout view


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
