### PR TITLE
Change styling for log entires

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -19,4 +19,5 @@ $pain-color: $yellow;
 $exercise-color: #48aa6c;
 $therapy-color: #0994a1;
 $slit-color: #8228d5;
+$slit-skipped-color: $red;
 

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -8,12 +8,14 @@ $medium-gray: #ccc;
 $error: ff0000;
 $white: #fff;
 $black: #000;
+$red: #c70039;
+$orange: #ed553b;
+$dk-blue: #112f41;
+$yellow: #f2b134;
+$light-yellow: lighten($yellow, 30%);
 
-$pain-color: #f2b134;
+$pain-color: $yellow;
 $exercise-color: #48aa6c;
 $therapy-color: #0994a1;
 $slit-color: #8228d5;
 
-$red: #c70039;
-$orange: #ed553b;
-$dk-blue: #112f41;

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -13,6 +13,7 @@ $orange: #ed553b;
 $dk-blue: #112f41;
 $yellow: #f2b134;
 $light-yellow: lighten($yellow, 30%);
+$yellow-highlighter: #ff0;
 
 $pain-color: $yellow;
 $exercise-color: #48aa6c;

--- a/app/assets/stylesheets/logs.scss
+++ b/app/assets/stylesheets/logs.scss
@@ -4,15 +4,16 @@
   margin-bottom: 1rem;
   width: 100%;
 }
-.card--padding-clear {padding: 0;}
+
+.card--padding-clear { padding: 0; }
 .card-body { padding: .6rem; }
 
 .card--icon-container {
-  display: flex;
   align-items: center;
-  width: 2rem;
   color: $white;
+  display: flex;
   justify-content: center;
+  width: 2rem;
 }
 
 .card--log-entry {
@@ -56,14 +57,14 @@
 .log-border-therapy { border: .125em solid $therapy-color; }
 .log-border-slit { border: .125em solid $slit-color; }
 
-.background-color-exercise {background-color: $exercise-color}
-.background-color-pain {background-color: $pain-color}
-.background-color-therapy {background-color: $therapy-color}
-.background-color-slit {background-color: $slit-color}
-.background-color-slit-skipped {background-color: $slit-skipped-color}
+.background-color-exercise { background-color: $exercise-color; }
+.background-color-pain { background-color: $pain-color; }
+.background-color-therapy { background-color: $therapy-color; }
+.background-color-slit { background-color: $slit-color; }
+.background-color-slit-skipped { background-color: $slit-skipped-color; }
 
-.color-exercise {color: $exercise-color}
-.color-pain {color: $pain-color}
-.color-therapy {color: $therapy-color}
-.color-slit {color: $slit-color}
-.color-slit-skipped {color: $slit-skipped-color}
+.color-exercise { color: $exercise-color; }
+.color-pain { color: $pain-color; }
+.color-therapy { color: $therapy-color; }
+.color-slit { color: $slit-color; }
+.color-slit-skipped { color: $slit-skipped-color; }

--- a/app/assets/stylesheets/logs.scss
+++ b/app/assets/stylesheets/logs.scss
@@ -33,8 +33,6 @@
   line-height: 1rem;
 }
 
-.dose-skipped { color: $red; }
-
 @mixin log-type-color($color) {
   .log-icon-color { color: $color; }
   .card-title { color: $color; }

--- a/app/assets/stylesheets/logs.scss
+++ b/app/assets/stylesheets/logs.scss
@@ -4,8 +4,16 @@
   margin-bottom: 1rem;
   width: 100%;
 }
-
+.card--padding-clear {padding: 0;}
 .card-body { padding: .6rem; }
+
+.card--icon-container {
+  display: flex;
+  align-items: center;
+  width: 2rem;
+  color: $white;
+  justify-content: center;
+}
 
 .card--log-entry {
   margin-bottom: 1rem;
@@ -43,7 +51,19 @@
 .log-type-therapy { @include log-type-color($therapy-color); }
 .log-type-slit { @include log-type-color($slit-color); }
 
-.log-border-exercise { border: 1px solid $exercise-color; }
-.log-border-pain { border: 1px solid $pain-color; }
-.log-border-therapy { border: 1px solid $therapy-color; }
-.log-border-slit { border: 1px solid $slit-color; }
+.log-border-exercise { border: .125em solid $exercise-color; }
+.log-border-pain { border: .125em solid $pain-color; }
+.log-border-therapy { border: .125em solid $therapy-color; }
+.log-border-slit { border: .125em solid $slit-color; }
+
+.background-color-exercise {background-color: $exercise-color}
+.background-color-pain {background-color: $pain-color}
+.background-color-therapy {background-color: $therapy-color}
+.background-color-slit {background-color: $slit-color}
+.background-color-slit-skipped {background-color: $slit-skipped-color}
+
+.color-exercise {color: $exercise-color}
+.color-pain {color: $pain-color}
+.color-therapy {color: $therapy-color}
+.color-slit {color: $slit-color}
+.color-slit-skipped {color: $slit-skipped-color}

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -64,6 +64,12 @@ body { background-color: $dk-blue; }
 
 .highlight-yellow {
   background-color: $yellow-highlighter;
-  margin: -3px;
-  padding: 3px;
+  margin: -10px -3px;
+  padding: 0px 3px;
+}
+
+@media print {
+  .highlight-yellow {
+    border: .5px solid $black;
+  }
 }

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -65,7 +65,7 @@ body { background-color: $dk-blue; }
 .highlight-yellow {
   background-color: $yellow-highlighter;
   margin: -10px -3px;
-  padding: 0px 3px;
+  padding: 0 3px;
 }
 
 @media print {

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -62,5 +62,8 @@ body { background-color: $dk-blue; }
   .exercise-description { margin-bottom: 0; }
 }
 
-.highlight-yellow { background-color: $light-yellow; }
-
+.highlight-yellow {
+  background-color: $yellow-highlighter;
+  margin: -3px;
+  padding: 3px;
+}

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -61,3 +61,6 @@ body { background-color: $dk-blue; }
 
   .exercise-description { margin-bottom: 0; }
 }
+
+.highlight-yellow { background-color: $light-yellow; }
+

--- a/app/assets/stylesheets/slit.scss
+++ b/app/assets/stylesheets/slit.scss
@@ -38,4 +38,10 @@
   }
 }
 
+@media print {
+  .slit-report-col-dose {
+    width: 1rem;
+  }
+}
+
 

--- a/app/assets/stylesheets/slit.scss
+++ b/app/assets/stylesheets/slit.scss
@@ -24,6 +24,8 @@
   width: 3rem;
 }
 
+.dose-skipped { color: $red; }
+
 // MEDIA QUERIES
 @media (max-width: 576px) {
   .slit-report-data-container {

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -10,3 +10,5 @@
 
 
 .inline-block { display: inline-block; }
+
+.flex {display: flex;}

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -11,4 +11,4 @@
 
 .inline-block { display: inline-block; }
 
-.flex {display: flex;}
+.flex { display: flex; }

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -59,7 +59,6 @@ class SlitLogsController < ApplicationController
 
   def report
     report_record_limit = 90
-    @index_to_prompt_calling = 45
     @logs = current_user.slit_logs
                         .where(occurred_at: report_record_limit.days.ago..Time.current)
                         .order(occurred_at: :asc)

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -59,6 +59,7 @@ class SlitLogsController < ApplicationController
 
   def report
     report_record_limit = 90
+    @index_to_prompt_calling = 45
     @logs = current_user.slit_logs
                         .where(occurred_at: report_record_limit.days.ago..Time.current)
                         .order(occurred_at: :asc)

--- a/app/models/slit_log.rb
+++ b/app/models/slit_log.rb
@@ -4,4 +4,6 @@ class SlitLog < ApplicationRecord
   belongs_to :user
 
   validates :occurred_at, presence: true
+
+  DOSE_TO_PLACE_ORDER = 60
 end

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -10,6 +10,7 @@ class SlitLogSkippedDoseService
         Rails.logger.debug "last_log: #{last_log.occurred_at}"
         Rails.logger.debug "last_log.occurred_at.to_date: #{last_log.occurred_at.to_date}"
         Rails.logger.debug "Date.yesterday: #{Date.yesterday}"
+        binding.pry
         Rails.logger.debug "no_log_yesterday?: #{no_log_yesterday?(last_log)}"
         Rails.logger.debug "yes log yesterday: #{last_log&.occurred_at&.to_date == Date.yesterday}"
         next unless no_log_yesterday?(last_log)
@@ -18,12 +19,12 @@ class SlitLogSkippedDoseService
         user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
         Rails.logger.debug "========================================================="
       end
+    end
 
-      private
+    private
 
-      def no_log_yesterday?(last_log)
-        last_log.nil? || (last_log.occurred_at.to_date != Date.yesterday)
-      end
+    def no_log_yesterday?(last_log)
+      last_log.nil? || (last_log.occurred_at.to_date != Date.yesterday)
     end
   end
 end

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -4,20 +4,19 @@ class SlitLogSkippedDoseService
   class << self
     def call
       User.with_slit_enabled.each do |user|
-        Rails.logger.debug "==============SlitLogSkippedDoseService=================="
-        puts "putsing just for fun"
-        Rails.logger.debug "user: #{user.email}"
+        puts "==============SlitLogSkippedDoseService=================="
+        puts "user: #{user.email}"
         last_log = user.slit_logs.order(occurred_at: :desc).limit(1).first
-        Rails.logger.debug "last_log: #{last_log.occurred_at}"
-        Rails.logger.debug "last_log.occurred_at.to_date: #{last_log.occurred_at.to_date}"
-        Rails.logger.debug "Date.yesterday: #{Date.yesterday}"
-        Rails.logger.debug "no_log_yesterday?: #{no_log_yesterday?(last_log)}"
-        Rails.logger.debug "yes log yesterday: #{last_log&.occurred_at&.to_date == Date.yesterday}"
+        puts "last_log: #{last_log.occurred_at}"
+        puts "last_log.occurred_at.to_date: #{last_log.occurred_at.to_date}"
+        puts "Date.yesterday: #{Date.yesterday}"
+        puts "no_log_yesterday?: #{no_log_yesterday?(last_log)}"
+        puts "yes log yesterday: #{last_log&.occurred_at&.to_date == Date.yesterday}"
         next unless no_log_yesterday?(last_log)
-        Rails.logger.debug "DateTime.yesterday: #{DateTime.yesterday}"
-        Rails.logger.debug "Creating SLIT log for: #{DateTime.yesterday}"
+        puts "DateTime.yesterday: #{DateTime.yesterday}"
+        puts "Creating SLIT log for: #{DateTime.yesterday}"
         user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
-        Rails.logger.debug "========================================================="
+        puts "========================================================="
       end
     end
 

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -1,12 +1,29 @@
 # frozen_string_literal: true
 
 class SlitLogSkippedDoseService
-  def self.call
-    User.with_slit_enabled.each do |user|
-      last_log = user.slit_logs.order(occurred_at: :desc).limit(1).first
-      next unless last_log.nil? || (last_log.occurred_at.to_date != Date.yesterday)
+  class << self
+    def call
+      User.with_slit_enabled.each do |user|
+        Rails.logger.debug "==============SlitLogSkippedDoseService=================="
+        Rails.logger.debug "user: #{user.email}"
+        last_log = user.slit_logs.order(occurred_at: :desc).limit(1).first
+        Rails.logger.debug "last_log: #{last_log.occurred_at}"
+        Rails.logger.debug "last_log.occurred_at.to_date: #{last_log.occurred_at.to_date}"
+        Rails.logger.debug "Date.yesterday: #{Date.yesterday}"
+        Rails.logger.debug "no_log_yesterday?: #{no_log_yesterday?(last_log)}"
+        Rails.logger.debug "yes log yesterday: #{last_log&.occurred_at&.to_date == Date.yesterday}"
+        next unless no_log_yesterday?(last_log)
+        Rails.logger.debug "DateTime.yesterday: #{DateTime.yesterday}"
+        Rails.logger.debug "Creating SLIT log for: #{DateTime.yesterday}"
+        user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
+        Rails.logger.debug "========================================================="
+      end
 
-      user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
+      private
+
+      def no_log_yesterday?(last_log)
+        last_log.nil? || (last_log.occurred_at.to_date != Date.yesterday)
+      end
     end
   end
 end

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -10,7 +10,6 @@ class SlitLogSkippedDoseService
         Rails.logger.debug "last_log: #{last_log.occurred_at}"
         Rails.logger.debug "last_log.occurred_at.to_date: #{last_log.occurred_at.to_date}"
         Rails.logger.debug "Date.yesterday: #{Date.yesterday}"
-        binding.pry
         Rails.logger.debug "no_log_yesterday?: #{no_log_yesterday?(last_log)}"
         Rails.logger.debug "yes log yesterday: #{last_log&.occurred_at&.to_date == Date.yesterday}"
         next unless no_log_yesterday?(last_log)

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -5,6 +5,7 @@ class SlitLogSkippedDoseService
     def call
       User.with_slit_enabled.each do |user|
         Rails.logger.debug "==============SlitLogSkippedDoseService=================="
+        puts "putsing just for fun"
         Rails.logger.debug "user: #{user.email}"
         last_log = user.slit_logs.order(occurred_at: :desc).limit(1).first
         Rails.logger.debug "last_log: #{last_log.occurred_at}"

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -3,6 +3,8 @@
 class SlitLogSkippedDoseService
   class << self
     def call
+      yesterday = Date.yesterday
+
       User.with_slit_enabled.each do |user|
         puts "==============SlitLogSkippedDoseService=================="
         puts "user: #{user.email}"
@@ -12,7 +14,8 @@ class SlitLogSkippedDoseService
         puts "Date.yesterday: #{Date.yesterday}"
         puts "no_log_yesterday?: #{no_log_yesterday?(last_log)}"
         puts "yes log yesterday: #{last_log&.occurred_at&.to_date == Date.yesterday}"
-        next unless no_log_yesterday?(last_log)
+        puts "no_log_for_user_yesterday?: #{no_log_for_user_yesterday?(user: user, yesterday: yesterday)}"
+        next unless no_log_for_user_yesterday?(user: user, yesterday: yesterday)
         puts "DateTime.yesterday: #{DateTime.yesterday}"
         puts "Creating SLIT log for: #{DateTime.yesterday}"
         user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
@@ -22,7 +25,12 @@ class SlitLogSkippedDoseService
 
     private
 
+    def no_log_for_user_yesterday?(user:, yesterday:)
+      user.slit_logs.where(occurred_at: yesterday.beginning_of_day..yesterday.end_of_day).empty?
+    end
+
     def no_log_yesterday?(last_log)
+
       last_log.nil? || (last_log.occurred_at.to_date != Date.yesterday)
     end
   end

--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -6,20 +6,9 @@ class SlitLogSkippedDoseService
       yesterday = Date.yesterday
 
       User.with_slit_enabled.each do |user|
-        puts "==============SlitLogSkippedDoseService=================="
-        puts "user: #{user.email}"
-        last_log = user.slit_logs.order(occurred_at: :desc).limit(1).first
-        puts "last_log: #{last_log.occurred_at}"
-        puts "last_log.occurred_at.to_date: #{last_log.occurred_at.to_date}"
-        puts "Date.yesterday: #{Date.yesterday}"
-        puts "no_log_yesterday?: #{no_log_yesterday?(last_log)}"
-        puts "yes log yesterday: #{last_log&.occurred_at&.to_date == Date.yesterday}"
-        puts "no_log_for_user_yesterday?: #{no_log_for_user_yesterday?(user: user, yesterday: yesterday)}"
         next unless no_log_for_user_yesterday?(user: user, yesterday: yesterday)
-        puts "DateTime.yesterday: #{DateTime.yesterday}"
-        puts "Creating SLIT log for: #{DateTime.yesterday}"
+
         user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
-        puts "========================================================="
       end
     end
 
@@ -27,11 +16,6 @@ class SlitLogSkippedDoseService
 
     def no_log_for_user_yesterday?(user:, yesterday:)
       user.slit_logs.where(occurred_at: yesterday.beginning_of_day..yesterday.end_of_day).empty?
-    end
-
-    def no_log_yesterday?(last_log)
-
-      last_log.nil? || (last_log.occurred_at.to_date != Date.yesterday)
     end
   end
 end

--- a/app/views/exercise_logs/_exercise_log.html.erb
+++ b/app/views/exercise_logs/_exercise_log.html.erb
@@ -1,13 +1,19 @@
 <div class="card card--log-entry log-border-exercise">
   <a href="<%= exercise_log_path(exercise_log) %>">
-    <div class="card-body">
-      <%= render partial: 'exercise_logs/exercise_log_header', locals: { log: exercise_log } %>
+    <div class="card--padding-clear flex">
 
-      <p class="card-text"><strong><%= exercise_log.body_part_name.titleize %>:</strong> <%= exercise_log.exercise_name.titleize %>: <%= format_exercise_stats(exercise_log) %><br>
-        <% unless exercise_log.burn_rep.blank? && exercise_log.progress_note.blank? %>
-          <small class="text-muted">Progress: exercise burn at Set <%= exercise_log.burn_set %> / Rep <%= exercise_log.burn_rep %>.<%= format_resistance(exercise_log) %> <%= exercise_log.progress_note %></small>
-        <% end %>
-      </p>
+      <div class="card--icon-container background-color-exercise">
+        <span class="material-symbols-outlined">exercise</span>
+      </div>
+      <div class='card-body'>
+        <h5 class='card-title color-exercise'>Exercise: <%= format_datetime(exercise_log.occurred_at) %></h5>
+        <p class="card-text"><strong><%= exercise_log.body_part_name.titleize %>:</strong> <%= exercise_log.exercise_name.titleize %>: <%= format_exercise_stats(exercise_log) %><br>
+          <% unless exercise_log.burn_rep.blank? && exercise_log.progress_note.blank? %>
+            <small class="text-muted">Progress: exercise burn at Set <%= exercise_log.burn_set %> / Rep <%= exercise_log.burn_rep %>.<%= format_resistance(exercise_log) %> <%= exercise_log.progress_note %></small>
+          <% end %>
+        </p>
+      </div>
+
     </div>
   </a>
 </div>

--- a/app/views/pain_logs/_pain_log.html.erb
+++ b/app/views/pain_logs/_pain_log.html.erb
@@ -1,14 +1,19 @@
 <div class="card card--log-entry log-border-pain">
   <a href="<%= edit_pain_log_path(pain_log) %>">
-    <div class="card-body">
-      <%= render partial: 'pain_logs/pain_log_header', locals: { log: pain_log } %>
+    <div class="card--padding-clear flex">
+      <div class="card--icon-container background-color-pain">
+        <span class="material-symbols-outlined">recent_patient</span>
+      </div>
 
-      <p class="card-text"><strong><%= pain_log.body_part_name.titleize %>:</strong> Pain Level: <%= pain_log.pain_level %> <%= pain_log.pain_name %><br>
-        <%= pain_log.pain_description if pain_log.pain_description.present? %>
-        <% if pain_log.trigger.present? %>
-          <br><small class="text-muted">Triggered by: <%= pain_log.trigger %></small>
-        <% end %>
-      </p>
+      <div class='card-body'>
+        <h5 class='card-title color-pain'>Pain: <%= format_datetime(pain_log.occurred_at) %></h5>
+        <p class="card-text"><strong><%= pain_log.body_part_name.titleize %>:</strong> Pain Level: <%= pain_log.pain_level %> <%= pain_log.pain_name %><br>
+          <%= pain_log.pain_description if pain_log.pain_description.present? %>
+          <% if pain_log.trigger.present? %>
+            <br><small class="text-muted">Triggered by: <%= pain_log.trigger %></small>
+          <% end %>
+        </p>
+      </div>
     </div>
   </a>
 </div>

--- a/app/views/pt_session_logs/_pt_session_log.html.erb
+++ b/app/views/pt_session_logs/_pt_session_log.html.erb
@@ -1,11 +1,15 @@
 <div class='card card--log-entry log-border-therapy'>
   <a href='<%= pt_session_log_path(pt_session_log) %>'>
-    <div class='card-body'>
-      <%= render partial: 'pt_session_logs/pt_session_log_header', locals: { log: pt_session_log } %>
-
-      <p class='card-text'><strong><%= pt_session_log.body_part_name.titleize %>:</strong> <%= pt_session_log.duration %> minutes<br>
-        <small class='text-muted'><%= pt_session_log.exercise_notes %></small>
-      </p>
+    <div class="card--padding-clear flex">
+      <div class="card--icon-container background-color-therapy">
+        <span class="material-symbols-outlined">physical_therapy</span>
+      </div>
+      <div class='card-body'>
+        <h5 class='card-title color-therapy'>PT Session: <%= format_datetime(pt_session_log.occurred_at) %></h5>
+        <p class='card-text'><strong><%= pt_session_log.body_part_name.titleize %>:</strong> <%= pt_session_log.duration %> minutes<br>
+          <small class='text-muted'><%= pt_session_log.exercise_notes %></small>
+        </p>
+      </div>
     </div>
   </a>
 </div>

--- a/app/views/slit_logs/_slit_log.html.erb
+++ b/app/views/slit_logs/_slit_log.html.erb
@@ -1,17 +1,21 @@
 <div class="card card--log-entry log-border-slit">
   <a href="<%= edit_slit_log_path(slit_log) %>">
-    <div class="card-body">
-      <% if slit_log.dose_skipped? %>
-        <%= render partial: 'slit_logs/slit_log_skipped_dose_header', locals: { log: slit_log } %>
-      <% else %>
-        <%= render partial: 'slit_logs/slit_log_header', locals: { log: slit_log } %>
-      <% end %>
-
-      <p class="card-text">
-        <%= slit_log.dose_skipped? ? 'Skipped Dose' : 'Took drops' %>
-        <%= " | #{slit_log.doses_remaining} doses remaining" if slit_log.doses_remaining.present? %>
-        <%= ' (Started new bottle)' if slit_log.started_new_bottle? %>
-      </p>
+    <div class="card--padding-clear flex">
+      <div class="card--icon-container background-color-slit <%= 'background-color-slit-skipped' if slit_log.dose_skipped?%>">
+        <span class="material-symbols-outlined">colorize</span>
+      </div>
+      <div class='card-body'>
+        <% if slit_log.dose_skipped? %>
+          <h5 class='card-title color-slit-skipped'>SLIT Dose SKIPPED: <%= slit_log.occurred_at.strftime('%a %m/%d/%y') %></h5>
+        <% else %>
+          <h5 class='card-title color-slit'>SLIT Dose Taken: <%= format_datetime(slit_log.occurred_at) %></h5>
+        <% end %>
+        <p class="card-text">
+          <%= slit_log.dose_skipped? ? 'Skipped Dose' : 'Took drops' %>
+          <%= " | #{slit_log.doses_remaining} doses remaining" if slit_log.doses_remaining.present? %>
+          <%= ' (Started new bottle)' if slit_log.started_new_bottle? %>
+        </p>
+      </div>
     </div>
   </a>
 </div>

--- a/app/views/slit_logs/_slit_log_skipped_dose_header.html.erb
+++ b/app/views/slit_logs/_slit_log_skipped_dose_header.html.erb
@@ -1,4 +1,0 @@
-<header class='log-type-slit'>
-  <span class='log-icon dose-skipped'>SLIT Dose Skipped <span class="material-symbols-outlined">warning</span></span>
-  <h5 class='card-title'><%= "#{log.occurred_at.strftime('%a %m/%d/%y')} - SKIPPED"%></h5>
-</header>

--- a/app/views/slit_logs/_slit_log_skipped_dose_header.html.erb
+++ b/app/views/slit_logs/_slit_log_skipped_dose_header.html.erb
@@ -1,4 +1,4 @@
 <header class='log-type-slit'>
   <span class='log-icon dose-skipped'>SLIT Dose Skipped <span class="material-symbols-outlined">warning</span></span>
-  <h5 class='card-title'><%= "#{log.occurred_at.strftime('%a %m/%d/%y')} missing" if log.persisted? %></h5>
+  <h5 class='card-title'><%= "#{log.occurred_at.strftime('%a %m/%d/%y')} - SKIPPED"%></h5>
 </header>

--- a/app/views/slit_logs/report.html.erb
+++ b/app/views/slit_logs/report.html.erb
@@ -1,6 +1,6 @@
 <h2>Sublingual Immunotherapy Patient Documentation</h2>
 <p>Maintenance Dosage log for patient <%= current_user.email %> from <%= @logs.first.occurred_at.strftime('%m/%d/%y') %> to <%= @logs.last.occurred_at.strftime('%m/%d/%y') %></p>
-<p><strong>NB</strong> = started new bottle | <strong>SKIPPED</strong> = drops not taken for date | <strong>C</strong> = Call 336-659-4814 to order more drops</p>
+<p><strong>NB</strong> = started new bottle | <strong>SKIPPED</strong> = drops not taken for date | <strong>CALL</strong> = Call 336-659-4814 to order more drops</p>
 
 <div class='slit-report-data-container mt-4'>
   <% 3.times do %>
@@ -13,7 +13,7 @@
 
 <div class='slit-report-data-container'>
   <% @logs.each_with_index do |log, index| %>
-    <div class="slit-report-data-row <%= 'highlight-yellow' if index == @index_to_prompt_calling %>">
+    <div class="slit-report-data-row">
       <span class='slit-report-col-dose'><%= index + 1 %></span>
       <% if log.dose_skipped? %>
         <span><%= log.occurred_at.strftime('%a %m/%d/%y') %> <strong class="dose-skipped">SKIPPED</strong></span>
@@ -22,7 +22,7 @@
       <% end %>
 
       <% if index == @index_to_prompt_calling %>
-        <span><strong>C</strong></span>
+        <span class="<%= 'highlight-yellow' if index == @index_to_prompt_calling %>"><strong>CALL</strong></span>
       <% end %>
 
       <% if log.started_new_bottle? %>

--- a/app/views/slit_logs/report.html.erb
+++ b/app/views/slit_logs/report.html.erb
@@ -21,7 +21,7 @@
         <span><%= log.occurred_at.strftime('%a %m/%d/%y at %I:%M%p') %></span>
       <% end %>
 
-      <% if index == @index_to_prompt_calling %>
+      <% if index == SlitLog::DOSE_TO_PLACE_ORDER %>
         <span class="<%= 'highlight-yellow' if index == @index_to_prompt_calling %>"><strong>CALL</strong></span>
       <% end %>
 

--- a/app/views/slit_logs/report.html.erb
+++ b/app/views/slit_logs/report.html.erb
@@ -1,10 +1,6 @@
-<h1>Sublingual Immunotherapy Patient Documentation<br>Mantenance Dosage</h1>
-<h2>Call 336-659-4814 to order more drops</h2>
-<p>For <%= current_user.email %> from <%= @logs.first.occurred_at.strftime('%m/%d/%y') %> to <%= @logs.last.occurred_at.strftime('%m/%d/%y') %></p>
-<p>
-  <strong>NB</strong> = started new bottle<br>
-  <strong>SKIPPED</strong> = drops not taken for date
-</p>
+<h2>Sublingual Immunotherapy Patient Documentation</h2>
+<p>Maintenance Dosage log for patient <%= current_user.email %> from <%= @logs.first.occurred_at.strftime('%m/%d/%y') %> to <%= @logs.last.occurred_at.strftime('%m/%d/%y') %></p>
+<p><strong>NB</strong> = started new bottle | <strong>SKIPPED</strong> = drops not taken for date | <strong>C</strong> = Call 336-659-4814 to order more drops</p>
 
 <div class='slit-report-data-container mt-4'>
   <% 3.times do %>
@@ -17,12 +13,16 @@
 
 <div class='slit-report-data-container'>
   <% @logs.each_with_index do |log, index| %>
-    <div class="slit-report-data-row">
+    <div class="slit-report-data-row <%= 'highlight-yellow' if index == @index_to_prompt_calling %>">
       <span class='slit-report-col-dose'><%= index + 1 %></span>
       <% if log.dose_skipped? %>
-        <span><%= log.occurred_at.strftime('%m/%d/%y') %> <strong>SKIPPED</strong></span>
+        <span><%= log.occurred_at.strftime('%a %m/%d/%y') %> <strong class="dose-skipped">SKIPPED</strong></span>
       <% else %>
-        <span><%= log.occurred_at.strftime('%m/%d/%y at %I:%M%p') %></span>
+        <span><%= log.occurred_at.strftime('%a %m/%d/%y at %I:%M%p') %></span>
+      <% end %>
+
+      <% if index == @index_to_prompt_calling %>
+        <span><strong>C</strong></span>
       <% end %>
 
       <% if log.started_new_bottle? %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module TherapyTracker
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.logger = Logger.new(STDOUT)
+    # config.logger = Logger.new(STDOUT)
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,8 @@ module TherapyTracker
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
+    config.logger = Logger.new(STDOUT)
+
     # Don't generate system test files.
     config.generators.system_tests = nil
 

--- a/spec/views/exercise_logs/index.html.erb_spec.rb
+++ b/spec/views/exercise_logs/index.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'exercise_logs/index', type: :view do
     allow(view).to receive(:current_user).and_return(@user)
     render
     assert_select 'div.card-body>p', count: 2
-    assert_select 'div.card-body>header>h5', text: 'Sat 03/23/19 at 02:08PM', count: 2
+    assert_select 'div.card-body>h5', text: 'Exercise: Sat 03/23/19 at 02:08PM', count: 2
     assert_select 'div.card-body>p>strong', text: /Body Part\d+:/, count: 2
     assert_select 'div.card-body>p', text: %r{Exercise\d+: 2 sets / 10 reps at 5 seconds each}, count: 2
     assert_select 'div.card-body>p>small', text: %r{Progress: exercise burn at Set 2 / Rep 5.}, count: 2

--- a/spec/views/pain_logs/index.html.erb_spec.rb
+++ b/spec/views/pain_logs/index.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'pain_logs/index', type: :view do
     allow(view).to receive(:current_user).and_return(@user)
     render
     assert_select 'div.card-body>p', count: 2
-    assert_select 'div.card-body>header>h5', text: 'Mon 03/25/19 at 08:15PM', count: 2
+    assert_select 'div.card-body>h5', text: 'Pain: Mon 03/25/19 at 08:15PM', count: 2
     assert_select 'div.card-body>p>strong', text: /Body Part\d+:/, count: 2
     assert_select 'div.card-body>p', text: /Pain Level: \d /, count: 2
     assert_select 'div.card-body>p', text: /sample pain description/, count: 2

--- a/spec/views/pt_session_logs/index.html.erb_spec.rb
+++ b/spec/views/pt_session_logs/index.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'pt_session_logs/index', type: :view do
     allow(view).to receive(:current_user).and_return(@user)
     render
     assert_select 'div.card-body>p', count: 2
-    assert_select 'div.card-body>header>h5', text: 'Mon 03/25/19 at 10:29PM', count: 2
+    assert_select 'div.card-body>h5', text: 'PT Session: Mon 03/25/19 at 10:29PM', count: 2
     assert_select 'div.card-body>p>strong', text: /Body Part\d+:/, count: 2
     assert_select 'div.card-body>p', text: /\d{1,2} minutes/, count: 2
     assert_select 'div.card-body>p>small', text: /sample exercise notes/, count: 2


### PR DESCRIPTION
## Problems Solved
* makes the log type easier to see 
* makes the skipped slit log easier to see

## Screenshots

<img width="1060" alt="Screenshot 2024-03-20 at 7 05 43 PM" src="https://github.com/lortza/therapy_tracker/assets/8680712/d600e43c-2c94-41c6-8e9c-e135fcc2ff0b">

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
