### PR TITLE
Refactor logs partials

### DIFF
--- a/app/views/exercise_logs/_exercise_log.html.erb
+++ b/app/views/exercise_logs/_exercise_log.html.erb
@@ -1,19 +1,11 @@
-<div class="card card--log-entry log-border border-color-exercise">
-  <a href="<%= exercise_log_path(exercise_log) %>">
-    <div class="card--padding-clear flex">
+<% @card_body = capture do %>
+  <h5 class='card-title color-exercise'>Exercise: <%= format_datetime(exercise_log.occurred_at) %></h5>
+  <p class="card-text"><strong><%= exercise_log.body_part_name.titleize %>:</strong> <%= exercise_log.exercise_name.titleize %>: <%= format_exercise_stats(exercise_log) %><br>
+    <% unless exercise_log.burn_rep.blank? && exercise_log.progress_note.blank? %>
+      <small class="text-muted">Progress: exercise burn at Set <%= exercise_log.burn_set %> / Rep <%= exercise_log.burn_rep %>.<%= format_resistance(exercise_log) %> <%= exercise_log.progress_note %></small>
+    <% end %>
+  </p>
+<% end %>
 
-      <div class="card--icon-container background-color-exercise">
-        <span class="material-symbols-outlined">exercise</span>
-      </div>
-      <div class='card-body'>
-        <h5 class='card-title color-exercise'>Exercise: <%= format_datetime(exercise_log.occurred_at) %></h5>
-        <p class="card-text"><strong><%= exercise_log.body_part_name.titleize %>:</strong> <%= exercise_log.exercise_name.titleize %>: <%= format_exercise_stats(exercise_log) %><br>
-          <% unless exercise_log.burn_rep.blank? && exercise_log.progress_note.blank? %>
-            <small class="text-muted">Progress: exercise burn at Set <%= exercise_log.burn_set %> / Rep <%= exercise_log.burn_rep %>.<%= format_resistance(exercise_log) %> <%= exercise_log.progress_note %></small>
-          <% end %>
-        </p>
-      </div>
-
-    </div>
-  </a>
-</div>
+<!-- @card_body is rendered in the component below: -->
+<%= render partial: '/logs/log_component', locals: { log_type: 'exercise', edit_path: edit_exercise_log_path(exercise_log), icon_name: 'exercise', error_condition: false }%>

--- a/app/views/exercise_logs/_exercise_log_header.html.erb
+++ b/app/views/exercise_logs/_exercise_log_header.html.erb
@@ -1,4 +1,0 @@
-<header class='log-type-exercise'>
-  <span class='log-icon log-icon-color'>Exercise <i class='fal fa-dumbbell'></i></span>
-  <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
-</header>

--- a/app/views/exercise_logs/edit.html.erb
+++ b/app/views/exercise_logs/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, format_datetime(@exercise_log.occurred_at)) %>
 
-<%= render partial: 'exercise_logs/exercise_log_header', locals: { log: @exercise_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @exercise_log, log_type: 'exercise', log_name: 'Exercise', icon_name: 'exercise' } %>
 <h1>Editing <%= @exercise_log.exercise_name %></h1>
 
 <%= render 'form', exercise_log: @exercise_log, url: exercise_log_path(@exercise_log) %>

--- a/app/views/exercise_logs/new.html.erb
+++ b/app/views/exercise_logs/new.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'exercise_logs/exercise_log_header', locals: { log: @exercise_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @exercise_log, log_type: 'exercise', log_name: 'Exercise', icon_name: 'exercise' } %>
 
 <h1>Log an Exercise</h1>
 

--- a/app/views/exercise_logs/show.html.erb
+++ b/app/views/exercise_logs/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, format_datetime(@exercise_log.occurred_at)) %>
 
-<%= render partial: 'exercise_logs/exercise_log_header', locals: { log: @exercise_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @exercise_log, log_type: 'exercise', log_name: 'Exercise', icon_name: 'exercise' } %>
 
 <h2>
   <span class='pull-right'>

--- a/app/views/logs/_log_component.html.erb
+++ b/app/views/logs/_log_component.html.erb
@@ -1,0 +1,12 @@
+<div class="card card--log-entry log-border border-color-<%= log_type %>">
+  <a href="<%= edit_path %>">
+    <div class="card--padding-clear flex">
+      <div class="card--icon-container background-color-<%= log_type %> <%= 'background-color-error' if error_condition %>">
+        <span class="material-symbols-outlined"><%= icon_name %></span>
+      </div>
+      <div class='card-body'>
+        <%= @card_body %>
+      </div>
+    </div>
+  </a>
+</div>

--- a/app/views/logs/_log_header.html.erb
+++ b/app/views/logs/_log_header.html.erb
@@ -1,4 +1,7 @@
 <header class='log-type-<%= log_type %>'>
-  <span class='log-icon log-icon-color'><%= log_name %> <i class='<%= icon_name %>'></i></span>
+  <span class='log-icon log-icon-color'>
+    <%= log_name %>
+    <span class="material-symbols-outlined"><%= icon_name %></span>
+  </span>
   <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
 </header>

--- a/app/views/logs/_log_header.html.erb
+++ b/app/views/logs/_log_header.html.erb
@@ -1,0 +1,4 @@
+<header class='log-type-<%= log_type %>'>
+  <span class='log-icon log-icon-color'><%= log_name %> <i class='<%= icon_name %>'></i></span>
+  <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
+</header>

--- a/app/views/pain_logs/_pain_log.html.erb
+++ b/app/views/pain_logs/_pain_log.html.erb
@@ -1,19 +1,12 @@
-<div class="card card--log-entry log-border border-color-pain">
-<a href="<%= edit_pain_log_path(pain_log) %>">
-    <div class="card--padding-clear flex">
-      <div class="card--icon-container background-color-pain">
-        <span class="material-symbols-outlined">recent_patient</span>
-      </div>
+<% @card_body = capture do %>
+  <h5 class='card-title color-pain'>Pain: <%= format_datetime(pain_log.occurred_at) %></h5>
+  <p class="card-text"><strong><%= pain_log.body_part_name.titleize %>:</strong> Pain Level: <%= pain_log.pain_level %> <%= pain_log.pain_name %><br>
+    <%= pain_log.pain_description if pain_log.pain_description.present? %>
+    <% if pain_log.trigger.present? %>
+      <br><small class="text-muted">Triggered by: <%= pain_log.trigger %></small>
+    <% end %>
+  </p>
+<% end %>
 
-      <div class='card-body'>
-        <h5 class='card-title color-pain'>Pain: <%= format_datetime(pain_log.occurred_at) %></h5>
-        <p class="card-text"><strong><%= pain_log.body_part_name.titleize %>:</strong> Pain Level: <%= pain_log.pain_level %> <%= pain_log.pain_name %><br>
-          <%= pain_log.pain_description if pain_log.pain_description.present? %>
-          <% if pain_log.trigger.present? %>
-            <br><small class="text-muted">Triggered by: <%= pain_log.trigger %></small>
-          <% end %>
-        </p>
-      </div>
-    </div>
-  </a>
-</div>
+<!-- @card_body is rendered in the component below: -->
+<%= render partial: '/logs/log_component', locals: { log_type: 'pain', edit_path: edit_pain_log_path(pain_log), icon_name: 'recent_patient', error_condition: false }%>

--- a/app/views/pain_logs/_pain_log_header.html.erb
+++ b/app/views/pain_logs/_pain_log_header.html.erb
@@ -1,4 +1,0 @@
-<header class='log-type-pain'>
-  <span class='log-icon log-icon-color'>Pain <i class='fal fa-user-injured'></i></span>
-  <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
-</header>

--- a/app/views/pain_logs/edit.html.erb
+++ b/app/views/pain_logs/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pain_logs/pain_log_header', locals: { log: @pain_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'fal fa-user-injured' } %>
 
 <h1>Editing Pain Log</h1>
 

--- a/app/views/pain_logs/edit.html.erb
+++ b/app/views/pain_logs/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'fal fa-user-injured' } %>
+<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'recent_patient' } %>
 
 <h1>Editing Pain Log</h1>
 

--- a/app/views/pain_logs/new.html.erb
+++ b/app/views/pain_logs/new.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pain_logs/pain_log_header', locals: { log: @pain_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'fal fa-user-injured' } %>
 
 <h1>New Pain Log</h1>
 

--- a/app/views/pain_logs/new.html.erb
+++ b/app/views/pain_logs/new.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'fal fa-user-injured' } %>
+<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'recent_patient' } %>
 
 <h1>New Pain Log</h1>
 

--- a/app/views/pain_logs/show.html.erb
+++ b/app/views/pain_logs/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'fal fa-user-injured' } %>
+<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'recent_patient' } %>
 
 <p>
   <strong>User:</strong>

--- a/app/views/pain_logs/show.html.erb
+++ b/app/views/pain_logs/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pain_logs/pain_log_header', locals: { log: @pain_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @pain_log, log_type: 'pain', log_name: 'Pain', icon_name: 'fal fa-user-injured' } %>
 
 <p>
   <strong>User:</strong>

--- a/app/views/pt_session_logs/_pt_session_log.html.erb
+++ b/app/views/pt_session_logs/_pt_session_log.html.erb
@@ -1,15 +1,9 @@
-<div class='card card--log-entry log-border border-color-therapy'>
-  <a href='<%= pt_session_log_path(pt_session_log) %>'>
-    <div class="card--padding-clear flex">
-      <div class="card--icon-container background-color-therapy">
-        <span class="material-symbols-outlined">physical_therapy</span>
-      </div>
-      <div class='card-body'>
-        <h5 class='card-title color-therapy'>PT Session: <%= format_datetime(pt_session_log.occurred_at) %></h5>
-        <p class='card-text'><strong><%= pt_session_log.body_part_name.titleize %>:</strong> <%= pt_session_log.duration %> minutes<br>
-          <small class='text-muted'><%= pt_session_log.exercise_notes %></small>
-        </p>
-      </div>
-    </div>
-  </a>
-</div>
+<% @card_body = capture do %>
+  <h5 class='card-title color-therapy'>PT Session: <%= format_datetime(pt_session_log.occurred_at) %></h5>
+  <p class='card-text'><strong><%= pt_session_log.body_part_name.titleize %>:</strong> <%= pt_session_log.duration %> minutes<br>
+    <small class='text-muted'><%= pt_session_log.exercise_notes %></small>
+  </p>
+<% end %>
+
+<!-- @card_body is rendered in the component below: -->
+<%= render partial: '/logs/log_component', locals: { log_type: 'therapy', edit_path: edit_pt_session_log_path(pt_session_log), icon_name: 'physical_therapy', error_condition: false } %>

--- a/app/views/pt_session_logs/_pt_session_log_header.html.erb
+++ b/app/views/pt_session_logs/_pt_session_log_header.html.erb
@@ -1,4 +1,0 @@
-<header class='log-type-therapy'>
-  <span class='log-icon log-icon-color'>PT Session <i class='fal fa-hospital-user'></i></span>
-  <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
-</header>

--- a/app/views/pt_session_logs/edit.html.erb
+++ b/app/views/pt_session_logs/edit.html.erb
@@ -1,4 +1,5 @@
-<%= render partial: 'pt_session_logs/pt_session_log_header', locals: { log: @pt_session_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @pt_session_log, log_type: 'therapy', log_name: 'PT Session', icon_name: 'physical_therapy' } %>
+
 <h1>Edit Session</h1>
 
 <%= render 'form', pt_session_log: @pt_session_log %>

--- a/app/views/pt_session_logs/new.html.erb
+++ b/app/views/pt_session_logs/new.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pt_session_logs/pt_session_log_header', locals: { log: @pt_session_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @pt_session_log, log_type: 'therapy', log_name: 'PT Session', icon_name: 'physical_therapy' } %>
 
 <h1>New Session</h1>
 

--- a/app/views/pt_session_logs/show.html.erb
+++ b/app/views/pt_session_logs/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'pt_session_logs/pt_session_log_header', locals: { log: @pt_session_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @pt_session_log, log_type: 'therapy', log_name: 'PT Session', icon_name: 'physical_therapy' } %>
 
 <h2>
   <span class='pull-right'>

--- a/app/views/slit_logs/_slit_log.html.erb
+++ b/app/views/slit_logs/_slit_log.html.erb
@@ -1,21 +1,15 @@
-<div class="card card--log-entry log-border border-color-slit">
-  <a href="<%= edit_slit_log_path(slit_log) %>">
-    <div class="card--padding-clear flex">
-      <div class="card--icon-container background-color-slit <%= 'background-color-error' if slit_log.dose_skipped?%>">
-        <span class="material-symbols-outlined">colorize</span>
-      </div>
-      <div class='card-body'>
-        <% if slit_log.dose_skipped? %>
-          <h5 class='card-title color-error'>SLIT Dose SKIPPED: <%= slit_log.occurred_at.strftime('%a %m/%d/%y') %></h5>
-        <% else %>
-          <h5 class='card-title color-slit'>SLIT Dose Taken: <%= format_datetime(slit_log.occurred_at) %></h5>
-        <% end %>
-        <p class="card-text">
-          <%= slit_log.dose_skipped? ? 'Skipped Dose' : 'Took drops' %>
-          <%= " | #{slit_log.doses_remaining} doses remaining" if slit_log.doses_remaining.present? %>
-          <%= ' (Started new bottle)' if slit_log.started_new_bottle? %>
-        </p>
-      </div>
-    </div>
-  </a>
-</div>
+<% @card_body = capture do %>
+  <% if slit_log.dose_skipped? %>
+    <h5 class='card-title color-error'>SLIT Dose SKIPPED: <%= slit_log.occurred_at.strftime('%a %m/%d/%y') %></h5>
+  <% else %>
+    <h5 class='card-title color-slit'>SLIT Dose Taken: <%= format_datetime(slit_log.occurred_at) %></h5>
+  <% end %>
+  <p class="card-text">
+  <%= slit_log.dose_skipped? ? 'Skipped Dose' : 'Took drops' %>
+  <%= " | #{slit_log.doses_remaining} doses remaining" if slit_log.doses_remaining.present? %>
+  <%= ' (Started new bottle)' if slit_log.started_new_bottle? %>
+  </p>
+<% end %>
+
+<!-- @card_body is rendered in the component below: -->
+<%= render partial: '/logs/log_component', locals: { log_type: 'slit', edit_path: edit_slit_log_path(slit_log), icon_name: 'colorize', error_condition: slit_log.dose_skipped? }%>

--- a/app/views/slit_logs/_slit_log.html.erb
+++ b/app/views/slit_logs/_slit_log.html.erb
@@ -5,9 +5,9 @@
     <h5 class='card-title color-slit'>SLIT Dose Taken: <%= format_datetime(slit_log.occurred_at) %></h5>
   <% end %>
   <p class="card-text">
-  <%= slit_log.dose_skipped? ? 'Skipped Dose' : 'Took drops' %>
-  <%= " | #{slit_log.doses_remaining} doses remaining" if slit_log.doses_remaining.present? %>
-  <%= ' (Started new bottle)' if slit_log.started_new_bottle? %>
+    <%= slit_log.dose_skipped? ? 'Skipped Dose' : 'Took drops' %>
+    <%= " | #{slit_log.doses_remaining} doses remaining" if slit_log.doses_remaining.present? %>
+    <%= ' (Started new bottle)' if slit_log.started_new_bottle? %>
   </p>
 <% end %>
 

--- a/app/views/slit_logs/_slit_log_header.html.erb
+++ b/app/views/slit_logs/_slit_log_header.html.erb
@@ -1,4 +1,0 @@
-<header class='log-type-slit'>
-  <span class='log-icon log-icon-color'>SLIT Dose <span class="material-symbols-outlined">colorize</span></span>
-  <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
-</header>

--- a/app/views/slit_logs/edit.html.erb
+++ b/app/views/slit_logs/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, format_datetime(@slit_log.occurred_at)) %>
 
-<%= render partial: 'slit_logs/slit_log_header', locals: { log: @slit_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @slit_log, log_type: 'slit', log_name: 'SLIT Dose', icon_name: 'colorize' } %>
 <h1>Editing Log from <%= @slit_log.occurred_at.strftime('%a %m/%d/%y') %></h1>
 
 <%= render 'form', slit_log: @slit_log, url: slit_logs_path(@slit_log) %>

--- a/app/views/slit_logs/new.html.erb
+++ b/app/views/slit_logs/new.html.erb
@@ -1,6 +1,7 @@
 <% content_for(:title, format_datetime(@slit_log.occurred_at)) %>
 
-<%= render partial: 'slit_logs/slit_log_header', locals: { log: @slit_log } %>
+<%= render partial: 'logs/log_header', locals: { log: @slit_log, log_type: 'slit', log_name: 'SLIT Dose', icon_name: 'colorize' } %>
+
 <h1>New SLIT Log</h1>
 
 <%= render 'form', slit_log: @slit_log, url: slit_logs_path(@slit_log) %>


### PR DESCRIPTION
## Problems Solved
When I recently added a 4th type of log to this app, I saw that there was a lot of redundancy in html and partials. It became apparent that it was time for an abstraction. Part of this work was restructuring the css to be more flexible. (see #779 ) This allowed me to pass values in dynamically to partials. This PR removes the redundant html and pulls it into dedicated partials:
* replaced 4 individual log header partials with a single shared header partial
* pulled rudundant html out of all log 

## Screenshots
[screenshots here]

## Things Learned
*

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
