### PR TITLE
Allow user profile editing

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  before_action :set_user, only: [:edit, :update]
+  before_action :set_return_to_destination, only: [:edit]
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to session.delete(:return_to)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_return_to_destination
+    session[:return_to] ||= request.referer
+  end
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:enable_slit_tracking)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :set_user, only: [:edit, :update]
+  before_action :set_user, only: %i[edit update]
   before_action :set_return_to_destination, only: [:edit]
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to session.delete(:return_to)
+      redirect_to session.fetch(:return_to, root_path)
     else
       render :edit
     end

--- a/app/views/shared/_add_log_buttons.html.erb
+++ b/app/views/shared/_add_log_buttons.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= render 'buttons/new_slit_log' %>
+  <%= render 'buttons/new_slit_log' if current_user.enable_slit_tracking %>
   <%= render 'buttons/new_pain_log' %>
   <%= render 'buttons/new_exercise_log' %>
   <%= render 'buttons/new_pt_session_log' %>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -7,7 +7,7 @@
       <%= link_to '+ Exercise Log', new_exercise_log_path, class: 'dropdown-item' %>
       <%= link_to '+ Pain Log', new_pain_log_path, class: 'dropdown-item' %>
       <%= link_to '+ PT Session', new_pt_session_log_path, class: 'dropdown-item' %>
-      <%= link_to '+ SLIT Log', new_slit_log_path, class: 'dropdown-item' %>
+      <%= link_to '+ SLIT Log', new_slit_log_path, class: 'dropdown-item' if current_user.enable_slit_tracking %>
     </div>
   </li>
 
@@ -17,7 +17,7 @@
       Quick Log
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-      <%= link_to 'SLIT dose', quick_log_create_path, method: :post, class: 'dropdown-item'  %>
+      <%= link_to 'SLIT dose', quick_log_create_path, method: :post, class: 'dropdown-item' if current_user.enable_slit_tracking %>
       <% current_user.pain_log_quick_form_values.order(name: :asc).each do |attr| %>
         <%= link_to attr.name, create_pain_log_from_quick_form_path(content: attr), method: :post, class: 'dropdown-item'  %>
       <% end %>
@@ -32,7 +32,7 @@
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <%= link_to 'Pain Stats by Body Part', stats_path, class: 'dropdown-item' %>
       <%= link_to 'Charts', charts_path, class: 'dropdown-item' %>
-      <%= link_to 'SLIT Logs for Print', slit_report_path, class: 'dropdown-item' %>
+      <%= link_to 'SLIT Logs for Print', slit_report_path, class: 'dropdown-item' if current_user.enable_slit_tracking %>
       <div class='dropdown-divider'></div>
       <%= link_to 'Exercise Logs', exercise_logs_path, class: 'dropdown-item' %>
       <%= link_to 'Pain Logs', pain_logs_path, class: 'dropdown-item' %>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -58,7 +58,8 @@
         <%= current_user.email %>
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-      <%= link_to 'Edit My Profile', edit_user_registration_path, class: 'dropdown-item' %>
+      <%= link_to 'Edit My Profile', edit_user_path(current_user), class: 'dropdown-item' %>
+      <%= link_to 'Change My Password', edit_user_registration_path, class: 'dropdown-item' %>
       <%= link_to 'Log Out', destroy_user_session_path, method: :delete, class: 'dropdown-item' %>
     </div>
   </li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:title, 'Edit User Profile') %>
+
+<h1>Editing User Profile</h1>
+
+<%= form_with(model: @user, local: true) do |form| %>
+  <%= render partial: 'shared/errors', locals: {object: @user} %>
+
+  <div class='form-row'>
+    <div class='col-12 col-md-3'>
+      <div class='field'>
+        <%= form.label 'Enable SLIT Therapy Tracking?' %>
+        <%= form.check_box :enable_slit_tracking, class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+  <div class='mt-3 mb-3'>
+    <%= form.submit 'Submit', class: button_class('success') %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :show]
   end
 
+  resources :users, only: [:edit, :update]
+
+
   resources :charts, only: [:index]
   resources :stats, only: [:index]
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Users', type: :request do
+  let!(:user) { create(:user) }
+
+  describe 'Public access to users' do
+    it 'denies access to users#edit' do
+      get edit_user_path(user.id)
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it 'denies access to users#update' do
+      patch user_path(user, user: user.attributes)
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  describe 'Authenticated access to users' do
+    before { sign_in(user) }
+
+    describe '#edit' do
+      it 'renders users#edit' do
+        get edit_user_path(user.id)
+
+        expect(response).to be_successful
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe '#update' do
+      let(:user) { create(:user, enable_slit_tracking: false) }
+
+      it 'updates the user' do
+        patch user_path(user, user: { id: user.id, enable_slit_tracking: true })
+
+        expect(user.reload.enable_slit_tracking).to eq(true)
+      end
+
+      context 'when there is a return_to location' do
+        it 'redirects back to the previous url' do
+          session = { return_to: exercise_logs_path }
+          allow_any_instance_of(UsersController).to receive(:session).and_return(session)
+          patch user_path(user, user: { id: user.id, enable_slit_tracking: true })
+
+          expect(response).to redirect_to(exercise_logs_path)
+        end
+      end
+
+      context 'when there is not a return_to location' do
+        it 'redirects to the root_url' do
+          patch user_path(user, user: { id: user.id, enable_slit_tracking: true })
+
+          expect(response).to redirect_to(root_url)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
Closes #768

## Problems Solved
* now that a user has the option to tun on/off SLIT tracking, we need to give the user the ability to edit that setting
* this PR give the user a form to do that
* also show/hide buttons in the nav conditionally based on whether SLIT tracking is turned on for a person

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
