### PR TITLE
Move user id out of url params for profile edit

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
   end
 
   def set_user
-    @user = User.find(params[:id])
+    @user = current_user
   end
 
   def user_params

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -58,7 +58,7 @@
         <%= current_user.email %>
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-      <%= link_to 'Edit My Profile', edit_user_path(current_user), class: 'dropdown-item' %>
+      <%= link_to 'Edit My Settings', edit_user_settings_path, class: 'dropdown-item' %>
       <%= link_to 'Change My Password', edit_user_registration_path, class: 'dropdown-item' %>
       <%= link_to 'Log Out', destroy_user_session_path, method: :delete, class: 'dropdown-item' %>
     </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,17 +1,13 @@
-<% content_for(:title, 'Edit User Profile') %>
+<% content_for(:title, 'Edit My Settings') %>
 
-<h1>Editing User Profile</h1>
+<h1>My Settings</h1>
 
 <%= form_with(model: @user, local: true) do |form| %>
   <%= render partial: 'shared/errors', locals: {object: @user} %>
 
-  <div class='form-row'>
-    <div class='col-12 col-md-3'>
-      <div class='field'>
-        <%= form.label 'Enable SLIT Therapy Tracking?' %>
-        <%= form.check_box :enable_slit_tracking, class: 'form-control' %>
-      </div>
-    </div>
+  <div class='field'>
+    <%= form.check_box :enable_slit_tracking %>
+    <label class="mb-0 inline">Enable SLIT Therapy Tracking</label>
   </div>
 
   <div class='mt-3 mb-3'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,8 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :show]
   end
 
-  resources :users, only: [:edit, :update]
-
+  resources :users, only: [:update]
+  get 'users/settings', action: :edit, controller: 'users', as: 'edit_user_settings'
 
   resources :charts, only: [:index]
   resources :stats, only: [:index]

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'Users', type: :request do
 
   describe 'Public access to users' do
     it 'denies access to users#edit' do
-      get edit_user_path(user.id)
-      expect(response).to redirect_to new_user_session_path
+      get edit_user_settings_path(user.id)
+      expect(response).to be_unauthorized
     end
 
     it 'denies access to users#update' do
@@ -22,7 +22,7 @@ RSpec.describe 'Users', type: :request do
 
     describe '#edit' do
       it 'renders users#edit' do
-        get edit_user_path(user.id)
+        get edit_user_settings_path(user.id)
 
         expect(response).to be_successful
         expect(response).to render_template(:edit)


### PR DESCRIPTION
## Problems Solved
* keeps the user id private by keeping it out of the url params for the user profile edit page

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
