### PR TITLE
Implement draper gem

### DIFF
--- a/app/controllers/exercise_logs_controller.rb
+++ b/app/controllers/exercise_logs_controller.rb
@@ -6,10 +6,12 @@ class ExerciseLogsController < ApplicationController
   layout 'no_white_container', only: [:index]
 
   def index
-    @logs = current_user.exercise_logs
+    logs = current_user.exercise_logs
                         .at_home
                         .order(occurred_at: 'DESC')
                         .paginate(page: params[:page], per_page: 25)
+
+    @logs = ExerciseLogDecorator.decorate_collection(logs)
   end
 
   def show
@@ -17,7 +19,7 @@ class ExerciseLogsController < ApplicationController
   end
 
   def new
-    @exercise_log = current_user.exercise_logs.new
+    @exercise_log = current_user.exercise_logs.new.decorate
   end
 
   def edit
@@ -64,7 +66,7 @@ class ExerciseLogsController < ApplicationController
   end
 
   def set_exercise_log
-    @exercise_log = ExerciseLog.find(params[:id])
+    @exercise_log = ExerciseLog.find(params[:id]).decorate
   end
 
   def exercise_log_params

--- a/app/controllers/exercise_logs_controller.rb
+++ b/app/controllers/exercise_logs_controller.rb
@@ -7,9 +7,9 @@ class ExerciseLogsController < ApplicationController
 
   def index
     logs = current_user.exercise_logs
-                        .at_home
-                        .order(occurred_at: 'DESC')
-                        .paginate(page: params[:page], per_page: 25)
+                       .at_home
+                       .order(occurred_at: 'DESC')
+                       .paginate(page: params[:page], per_page: 25)
 
     @logs = ExerciseLogDecorator.decorate_collection(logs)
   end

--- a/app/controllers/pain_logs_controller.rb
+++ b/app/controllers/pain_logs_controller.rb
@@ -7,11 +7,11 @@ class PainLogsController < ApplicationController
 
   def index
     logs = current_user.pain_logs
-                        .search(body_part_id: search_params[:body_part_id],
-                          pain_id: search_params[:pain_id],
-                          search_terms: search_params[:search])
-                        .order(occurred_at: 'DESC')
-                        .paginate(page: params[:page], per_page: 25)
+                       .search(body_part_id: search_params[:body_part_id],
+                               pain_id: search_params[:pain_id],
+                               search_terms: search_params[:search])
+                       .order(occurred_at: 'DESC')
+                       .paginate(page: params[:page], per_page: 25)
 
     @logs = PainLogDecorator.decorate_collection(logs)
   end

--- a/app/controllers/pain_logs_controller.rb
+++ b/app/controllers/pain_logs_controller.rb
@@ -6,19 +6,21 @@ class PainLogsController < ApplicationController
   layout 'no_white_container', only: [:index]
 
   def index
-    @logs = current_user.pain_logs
+    logs = current_user.pain_logs
                         .search(body_part_id: search_params[:body_part_id],
-                                pain_id: search_params[:pain_id],
-                                search_terms: search_params[:search])
+                          pain_id: search_params[:pain_id],
+                          search_terms: search_params[:search])
                         .order(occurred_at: 'DESC')
                         .paginate(page: params[:page], per_page: 25)
+
+    @logs = PainLogDecorator.decorate_collection(logs)
   end
 
   def show
   end
 
   def new
-    @pain_log = current_user.pain_logs.new
+    @pain_log = current_user.pain_logs.new.decorate
   end
 
   def edit
@@ -70,7 +72,7 @@ class PainLogsController < ApplicationController
   private
 
   def set_pain_log
-    @pain_log = current_user.pain_logs.find(params[:id])
+    @pain_log = current_user.pain_logs.find(params[:id]).decorate
   end
 
   def authorize_pain_log

--- a/app/controllers/pt_session_logs_controller.rb
+++ b/app/controllers/pt_session_logs_controller.rb
@@ -6,14 +6,15 @@ class PtSessionLogsController < ApplicationController
   layout 'no_white_container', only: [:index]
 
   def index
-    @logs = current_user.pt_session_logs.order(occurred_at: 'DESC').paginate(page: params[:page], per_page: 10)
+    logs = current_user.pt_session_logs.order(occurred_at: 'DESC').paginate(page: params[:page], per_page: 10)
+    @logs = PtSessionLogDecorator.decorate_collection(logs)
   end
 
   def show
   end
 
   def new
-    @pt_session_log = current_user.pt_session_logs.new
+    @pt_session_log = current_user.pt_session_logs.new.decorate
   end
 
   def edit
@@ -56,7 +57,7 @@ class PtSessionLogsController < ApplicationController
   private
 
   def set_pt_session_log
-    @pt_session_log = PtSessionLog.find(params[:id])
+    @pt_session_log = PtSessionLog.find(params[:id]).decorate
   end
 
   def authorize_pt_session_log

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -6,9 +6,11 @@ class SlitLogsController < ApplicationController
   layout 'no_white_container', only: [:index]
 
   def index
-    @logs = current_user.slit_logs
+    logs = current_user.slit_logs
                         .order(occurred_at: 'DESC')
                         .paginate(page: params[:page], per_page: 25)
+
+    @logs = SlitLogDecorator.decorate_collection(logs)
   end
 
   def edit
@@ -17,7 +19,7 @@ class SlitLogsController < ApplicationController
   def new
     @slit_log = current_user.slit_logs.new(
       occurred_at: Time.current
-    )
+    ).decorate
   end
 
   def create
@@ -60,16 +62,18 @@ class SlitLogsController < ApplicationController
   def report
     report_record_limit = 90
     @index_to_prompt_calling = 45
-    @logs = current_user.slit_logs
+    logs = current_user.slit_logs
                         .where(occurred_at: report_record_limit.days.ago..Time.current)
                         .order(occurred_at: :asc)
                         .limit(report_record_limit)
+
+    @logs = SlitLogDecorator.decorate_collection(logs)
   end
 
   private
 
   def set_slit_log
-    @slit_log = current_user.slit_logs.find(params[:id])
+    @slit_log = current_user.slit_logs.find(params[:id]).decorate
   end
 
   def authorize_slit_log

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -7,8 +7,8 @@ class SlitLogsController < ApplicationController
 
   def index
     logs = current_user.slit_logs
-                        .order(occurred_at: 'DESC')
-                        .paginate(page: params[:page], per_page: 25)
+                       .order(occurred_at: 'DESC')
+                       .paginate(page: params[:page], per_page: 25)
 
     @logs = SlitLogDecorator.decorate_collection(logs)
   end
@@ -63,9 +63,9 @@ class SlitLogsController < ApplicationController
     report_record_limit = 90
     @index_to_prompt_calling = 45
     logs = current_user.slit_logs
-                        .where(occurred_at: report_record_limit.days.ago..Time.current)
-                        .order(occurred_at: :asc)
-                        .limit(report_record_limit)
+                       .where(occurred_at: report_record_limit.days.ago..Time.current)
+                       .order(occurred_at: :asc)
+                       .limit(report_record_limit)
 
     @logs = SlitLogDecorator.decorate_collection(logs)
   end

--- a/app/decorators/exercise_log_decorator.rb
+++ b/app/decorators/exercise_log_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ExerciseLogDecorator < ApplicationDecorator
+  delegate_all
+
+  def display_name
+    'Exercise'
+  end
+
+  def icon_name
+    'exercise'
+  end
+
+  def css_name
+    'exercise'
+  end
+end

--- a/app/decorators/pain_log_decorator.rb
+++ b/app/decorators/pain_log_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PainLogDecorator < ApplicationDecorator
+  delegate_all
+
+  def icon_name
+    'recent_patient'
+  end
+
+  def display_name
+    'Pain'
+  end
+
+  def css_name
+    'pain'
+  end
+end

--- a/app/decorators/pt_session_log_decorator.rb
+++ b/app/decorators/pt_session_log_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PtSessionLogDecorator < ApplicationDecorator
+  delegate_all
+
+  def display_name
+    'PT Session'
+  end
+
+  def icon_name
+    'physical_therapy'
+  end
+
+  def css_name
+    'therapy'
+  end
+end

--- a/app/decorators/slit_log_decorator.rb
+++ b/app/decorators/slit_log_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class SlitLogDecorator < ApplicationDecorator
+  delegate_all
+
+  def display_name
+    'SLIT Dose'
+  end
+
+  def icon_name
+    'colorize'
+  end
+
+  def css_name
+    'slit'
+  end
+end

--- a/app/models/concerns/log.rb
+++ b/app/models/concerns/log.rb
@@ -4,10 +4,10 @@ module Log
   # class methods for querying logs
   def self.all(user)
     logs = [
-      user.pt_session_logs.to_a,
-      user.pain_logs.to_a,
-      user.exercise_logs.at_home.to_a,
-      user.slit_logs.to_a,
+      user.pt_session_logs.decorate.to_a,
+      user.pain_logs.decorate.to_a,
+      user.exercise_logs.at_home.decorate.to_a,
+      user.slit_logs.decorate.to_a,
     ]
 
     logs.flatten.sort_by { |a| a[:occurred_at] }.reverse!

--- a/app/models/exercise_log.rb
+++ b/app/models/exercise_log.rb
@@ -68,20 +68,4 @@ class ExerciseLog < ApplicationRecord
   def blank_stats?
     sets.blank? || reps.blank?
   end
-
-  def display_name
-    'Exercise'
-  end
-
-  def self.icon_name
-    'exercise'
-  end
-
-  def icon_name
-    ExerciseLog.icon_name
-  end
-
-  def css_name
-    'exercise'
-  end
 end

--- a/app/models/pain_log.rb
+++ b/app/models/pain_log.rb
@@ -47,20 +47,4 @@ class PainLog < ApplicationRecord
   def self.with_search_terms(search_terms)
     where("concat_ws(' ', trigger, pain_description) ILIKE ?", "%#{search_terms}%")
   end
-
-  def display_name
-    'Pain'
-  end
-
-  def self.icon_name
-    'recent_patient'
-  end
-
-  def icon_name
-    PainLog.icon_name
-  end
-
-  def css_name
-    'pain'
-  end
 end

--- a/app/models/pt_session_log.rb
+++ b/app/models/pt_session_log.rb
@@ -29,20 +29,4 @@ class PtSessionLog < ApplicationRecord
     end
     output
   end
-
-  def display_name
-    'PT Session'
-  end
-
-  def self.icon_name
-    'physical_therapy'
-  end
-
-  def icon_name
-    PtSessionLog.icon_name
-  end
-
-  def css_name
-    'therapy'
-  end
 end

--- a/app/models/slit_log.rb
+++ b/app/models/slit_log.rb
@@ -6,20 +6,4 @@ class SlitLog < ApplicationRecord
   validates :occurred_at, presence: true
 
   DOSE_TO_PLACE_ORDER = 60
-
-  def display_name
-    'SLIT Dose'
-  end
-
-  def self.icon_name
-    'colorize'
-  end
-
-  def icon_name
-    SlitLog.icon_name
-  end
-
-  def css_name
-    'slit'
-  end
 end

--- a/app/views/buttons/_new_exercise_log.html.erb
+++ b/app/views/buttons/_new_exercise_log.html.erb
@@ -1,1 +1,1 @@
-<%= link_to MaterialIcon.new(icon: ExerciseLog.icon_name, size: :large).render + '<br>+Exercise'.html_safe, new_exercise_log_path, class: 'add-log-button exercise-button' %>
+<%= link_to MaterialIcon.new(icon: ExerciseLog.new.decorate.icon_name, size: :large).render + '<br>+Exercise'.html_safe, new_exercise_log_path, class: 'add-log-button exercise-button' %>

--- a/app/views/buttons/_new_pain_log.html.erb
+++ b/app/views/buttons/_new_pain_log.html.erb
@@ -1,1 +1,1 @@
-<%= link_to MaterialIcon.new(icon: PainLog.icon_name, size: :large).render + '<br>+Pain'.html_safe, new_pain_log_path, class: 'add-log-button pain-button' %>
+<%= link_to MaterialIcon.new(icon: PainLog.new.decorate.icon_name, size: :large).render + '<br>+Pain'.html_safe, new_pain_log_path, class: 'add-log-button pain-button' %>

--- a/app/views/buttons/_new_pt_session_log.html.erb
+++ b/app/views/buttons/_new_pt_session_log.html.erb
@@ -1,1 +1,1 @@
-<%= link_to MaterialIcon.new(icon: PtSessionLog.icon_name, size: :large).render + '<br>+PT'.html_safe, new_pt_session_log_path, class: 'add-log-button therapy-button' %>
+<%= link_to MaterialIcon.new(icon: PtSessionLog.new.decorate.icon_name, size: :large).render + '<br>+PT'.html_safe, new_pt_session_log_path, class: 'add-log-button therapy-button' %>

--- a/app/views/buttons/_new_slit_log.html.erb
+++ b/app/views/buttons/_new_slit_log.html.erb
@@ -1,1 +1,1 @@
-<%= link_to MaterialIcon.new(icon: SlitLog.icon_name, size: :large).render + '<br>+SLIT'.html_safe, quick_log_create_path, method: :post, class: 'add-log-button slit-button' %>
+<%= link_to MaterialIcon.new(icon: SlitLog.new.decorate.icon_name, size: :large).render + '<br>+SLIT'.html_safe, quick_log_create_path, method: :post, class: 'add-log-button slit-button' %>

--- a/app/views/exercise_logs/edit.html.erb
+++ b/app/views/exercise_logs/edit.html.erb
@@ -5,7 +5,7 @@
 
 <%= render 'form', exercise_log: @exercise_log, url: exercise_log_path(@exercise_log) %>
 
-<%= render partial: 'shared/delete_footer', locals: { object: @exercise_log, delete_path: @exercise_log } %>
+<%= render partial: 'logs/delete_footer', locals: { object: @exercise_log, delete_path: @exercise_log } %>
 
 <script>
   // burnDropdowns(<%= @exercise_log.sets %>, <%= @exercise_log.reps %>)

--- a/app/views/logs/_delete_footer.html.erb
+++ b/app/views/logs/_delete_footer.html.erb
@@ -1,0 +1,9 @@
+<details>
+  <summary class='mt-4 border-top border-secondary'><h5 class="inline-block pt-3">Danger Zone</h5></summary>
+  <footer>
+    <p>Deleting this <%= object.display_name %> cannot be undone.
+      <%= link_to "Click to delete #{object.display_name}", delete_path,  method: :delete, data: { confirm: local_assigns[:message] ? message : 'Are you sure? This action cannot be undone.' }, class: "text-danger" %>.
+    </p>
+  </footer>
+</details>
+

--- a/app/views/pain_logs/edit.html.erb
+++ b/app/views/pain_logs/edit.html.erb
@@ -4,4 +4,4 @@
 
 <%= render 'form', pain_log: @pain_log %>
 
-<%= render partial: 'shared/delete_footer', locals: { object: @pain_log, delete_path: @pain_log } %>
+<%= render partial: 'logs/delete_footer', locals: { object: @pain_log, delete_path: @pain_log } %>

--- a/app/views/pt_session_logs/edit.html.erb
+++ b/app/views/pt_session_logs/edit.html.erb
@@ -4,4 +4,4 @@
 
 <%= render 'form', pt_session_log: @pt_session_log %>
 
-<%= render partial: 'shared/delete_footer', locals: { object: @pt_session_log, delete_path: @pt_session_log } %>
+<%= render partial: 'logs/delete_footer', locals: { object: @pt_session_log, delete_path: @pt_session_log } %>

--- a/app/views/shared/_delete_footer.html.erb
+++ b/app/views/shared/_delete_footer.html.erb
@@ -1,8 +1,8 @@
 <details>
   <summary class='mt-4 border-top border-secondary'><h5 class="inline-block pt-3">Danger Zone</h5></summary>
   <footer>
-    <p>Deleting this <%= object.class.name %> cannot be undone.
-      <%= link_to "Click to delete #{object.class.name}", delete_path,  method: :delete, data: { confirm: local_assigns[:message] ? message : 'Are you sure? This action cannot be undone.' }, class: "text-danger" %>.
+    <p>Deleting this <%= object.display_name %> cannot be undone.
+      <%= link_to "Click to delete #{object.display_name}", delete_path,  method: :delete, data: { confirm: local_assigns[:message] ? message : 'Are you sure? This action cannot be undone.' }, class: "text-danger" %>.
     </p>
   </footer>
 </details>

--- a/app/views/shared/_delete_footer.html.erb
+++ b/app/views/shared/_delete_footer.html.erb
@@ -1,8 +1,8 @@
 <details>
   <summary class='mt-4 border-top border-secondary'><h5 class="inline-block pt-3">Danger Zone</h5></summary>
   <footer>
-    <p>Deleting this <%= object.display_name %> cannot be undone.
-      <%= link_to "Click to delete #{object.display_name}", delete_path,  method: :delete, data: { confirm: local_assigns[:message] ? message : 'Are you sure? This action cannot be undone.' }, class: "text-danger" %>.
+    <p>Deleting this <%= object.class.name %> cannot be undone.
+      <%= link_to "Click to delete #{object.class.name}", delete_path,  method: :delete, data: { confirm: local_assigns[:message] ? message : 'Are you sure? This action cannot be undone.' }, class: "text-danger" %>.
     </p>
   </footer>
 </details>

--- a/app/views/slit_logs/edit.html.erb
+++ b/app/views/slit_logs/edit.html.erb
@@ -5,4 +5,4 @@
 
 <%= render 'form', slit_log: @slit_log, url: slit_logs_path(@slit_log) %>
 
-<%= render partial: 'shared/delete_footer', locals: { object: @slit_log, delete_path: @slit_log } %>
+<%= render partial: 'logs/delete_footer', locals: { object: @slit_log, delete_path: @slit_log } %>

--- a/spec/views/body_parts/edit.html.erb_spec.rb
+++ b/spec/views/body_parts/edit.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'body_parts/edit', type: :view do
     @user = create(:user)
     @body_part = assign(:body_part, BodyPart.create!(
                                       user_id: @user.id,
-                                      name: 'MyString',
+                                      name: 'My Body Part',
                                       archived: false
                                     ))
   end

--- a/spec/views/exercise_logs/edit.html.erb_spec.rb
+++ b/spec/views/exercise_logs/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'exercise_logs/edit', type: :view do
   before(:each) do
     @user = create(:user)
-    @exercise_log = create(:exercise_log, user_id: @user.id)
+    @exercise_log = create(:exercise_log, user_id: @user.id).decorate
   end
 
   it 'renders the edit exercise_log form' do

--- a/spec/views/exercise_logs/index.html.erb_spec.rb
+++ b/spec/views/exercise_logs/index.html.erb_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'exercise_logs/index', type: :view do
     @user = create(:user)
     create(:exercise_log, user_id: @user.id)
     create(:exercise_log, user_id: @user.id)
-    @logs = @user.exercise_logs.at_home
-                 .paginate(page: params[:page], per_page: 25)
+    logs = @user.exercise_logs.at_home.paginate(page: params[:page], per_page: 25)
+    @logs = ExerciseLogDecorator.decorate_collection(logs)
   end
 
   it 'renders a list of exercise_logs' do

--- a/spec/views/exercise_logs/new.html.erb_spec.rb
+++ b/spec/views/exercise_logs/new.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'exercise_logs/new', type: :view do
   before(:each) do
     @user = create(:user)
-    @exercise_log = build(:exercise_log, user_id: @user.id)
+    @exercise_log = build(:exercise_log, user_id: @user.id).decorate
   end
 
   it 'renders new exercise_log form' do

--- a/spec/views/exercise_logs/show.html.erb_spec.rb
+++ b/spec/views/exercise_logs/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'exercise_logs/show', type: :view do
   before(:each) do
     @user = create(:user)
-    @exercise_log = create(:exercise_log, user_id: @user.id)
+    @exercise_log = create(:exercise_log, user_id: @user.id).decorate
   end
 
   it 'renders attributes in <div>' do

--- a/spec/views/pain_logs/edit.html.erb_spec.rb
+++ b/spec/views/pain_logs/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'pain_logs/edit', type: :view do
   before(:each) do
     @user = create(:user)
-    @pain_log = create(:pain_log, user_id: @user.id)
+    @pain_log = create(:pain_log, user_id: @user.id).decorate
   end
 
   it 'renders the edit pain_log form' do

--- a/spec/views/pain_logs/index.html.erb_spec.rb
+++ b/spec/views/pain_logs/index.html.erb_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'pain_logs/index', type: :view do
     @user = create(:user)
     create(:pain_log, user_id: @user.id)
     create(:pain_log, user_id: @user.id)
-    @logs = @user.pain_logs.order(occurred_at: 'DESC').paginate(page: params[:page], per_page: 25)
+    logs = @user.pain_logs.order(occurred_at: 'DESC').paginate(page: params[:page], per_page: 25)
+    @logs = PainLogDecorator.decorate_collection(logs)
   end
 
   it 'renders a list of pain_logs' do

--- a/spec/views/pain_logs/new.html.erb_spec.rb
+++ b/spec/views/pain_logs/new.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'pain_logs/new', type: :view do
   before(:each) do
     @user = create(:user)
-    @pain_log = build(:pain_log, user_id: @user.id)
+    @pain_log = build(:pain_log, user_id: @user.id).decorate
   end
 
   it 'renders new pain_log form' do

--- a/spec/views/pain_logs/show.html.erb_spec.rb
+++ b/spec/views/pain_logs/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'pain_logs/show', type: :view do
   before(:each) do
     @user = create(:user)
-    @pain_log = create(:pain_log, user_id: @user.id)
+    @pain_log = create(:pain_log, user_id: @user.id).decorate
   end
 
   it 'renders attributes in <div>' do

--- a/spec/views/pt_session_logs/edit.html.erb_spec.rb
+++ b/spec/views/pt_session_logs/edit.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'pt_session_logs/edit', type: :view do
   before(:each) do
     @user = create(:user)
-    @pt_session_log = create(:pt_session_log, user_id: @user.id)
+    @pt_session_log = create(:pt_session_log, user_id: @user.id).decorate
   end
 
   it 'renders the edit pt_session_log form' do

--- a/spec/views/pt_session_logs/index.html.erb_spec.rb
+++ b/spec/views/pt_session_logs/index.html.erb_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'pt_session_logs/index', type: :view do
     @user = create(:user)
     create(:pt_session_log, user_id: @user.id)
     create(:pt_session_log, user_id: @user.id)
-    @logs = @user.pt_session_logs.order(occurred_at: 'DESC').paginate(page: params[:page], per_page: 10)
+    logs = @user.pt_session_logs.order(occurred_at: 'DESC').paginate(page: params[:page], per_page: 10)
+    @logs = PtSessionLogDecorator.decorate_collection(logs)
   end
 
   it 'renders a list of pt_session_logs' do

--- a/spec/views/pt_session_logs/new.html.erb_spec.rb
+++ b/spec/views/pt_session_logs/new.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'pt_session_logs/new', type: :view do
   before(:each) do
     @user = create(:user)
-    @pt_session_log = build(:pt_session_log, user_id: @user.id)
+    @pt_session_log = build(:pt_session_log, user_id: @user.id).decorate
   end
 
   it 'renders new pt_session_log form' do

--- a/spec/views/pt_session_logs/show.html.erb_spec.rb
+++ b/spec/views/pt_session_logs/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'pt_session_logs/show', type: :view do
   before(:each) do
     @user = create(:user)
-    @pt_session_log = create(:pt_session_log, user_id: @user.id)
+    @pt_session_log = create(:pt_session_log, user_id: @user.id).decorate
   end
 
   it 'renders attributes in <div>' do


### PR DESCRIPTION
## Related Issues & PRs
Relates to #788 
Closes #781

## Problems Solved
* Moves display concerns out of models and into decorators via the `draper` [gem](https://github.com/drapergem/draper)

## Things Learned
* Draper does not handle class methods
* I explored making `ExerciseLogClassDecorator` modules which were then extended in the `ExerciseLog` class models, but it felt messy and overly complex when I really only need it for one method right now. Instead, I am calling `ExerciseLog.new.decorate.icon_name` in the view for that once instance.
* I did not write specs for this work because there is no actual logic in the decorators
* Updating specs to include decorated objects is a PIA

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
