### PR TITLE
Convert button partials to button components

### DIFF
--- a/app/components/material_icon_component.rb
+++ b/app/components/material_icon_component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MaterialIcon
+class MaterialIconComponent
   # https://fonts.google.com/icons
   include ActionView::Helpers::TagHelper
 

--- a/app/components/new_log_button_component.rb
+++ b/app/components/new_log_button_component.rb
@@ -14,12 +14,15 @@ class NewLogButtonComponent
 
   private
 
+  # rubocop:disable Rails/OutputSafety
+  # Disabling is safe because this content ALWAYS comes from internal sources
   def button_text
     MaterialIconComponent.new(
       icon: decorated_log.icon_name,
       size: :large
     ).render + "<br>+#{computed_text}".html_safe
   end
+  # rubocop:enable Rails/OutputSafety
 
   def decorated_log
     @decorated_log ||= @log_klass.new.decorate

--- a/app/components/new_log_button_component.rb
+++ b/app/components/new_log_button_component.rb
@@ -1,30 +1,36 @@
 # frozen_string_literal: true
 
-# link_to MaterialIconComponent.new(icon: ExerciseLog.new.decorate.icon_name, size: :large).render + '<br>+Exercise'.html_safe, new_exercise_log_path, class: 'add-log-button exercise-button'
-
 class NewLogButtonComponent
-  # include ActionView::Helpers::TagHelper
-
-  def initialize(log_klass:, text: nil, path:, method: :get, classes: nil)
+  def initialize(log_klass:, text: nil, path: nil, method: :get)
     @log_klass = log_klass
-    @text = text || decorated_log.display_name
+    @text = text
     @path = path
     @method = method
-    @classes = classes
   end
 
   def render
-    ActionController::Base.helpers.link_to(button_text, @path, method: @method, class: computed_classes)
+    ActionController::Base.helpers.link_to(button_text, computed_path, method: @method, class: computed_classes)
   end
 
   private
 
   def button_text
-    MaterialIconComponent.new(icon: decorated_log.icon_name, size: :large).render + "<br>+#{@text}".html_safe
+    MaterialIconComponent.new(
+      icon: decorated_log.icon_name,
+      size: :large
+    ).render + "<br>+#{computed_text}".html_safe
   end
 
   def decorated_log
     @decorated_log ||= @log_klass.new.decorate
+  end
+
+  def computed_path
+    @path || "#{@log_klass.to_s.underscore}s/new"
+  end
+
+  def computed_text
+    @text || decorated_log.display_name
   end
 
   def computed_classes

--- a/app/components/new_log_button_component.rb
+++ b/app/components/new_log_button_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# link_to MaterialIconComponent.new(icon: ExerciseLog.new.decorate.icon_name, size: :large).render + '<br>+Exercise'.html_safe, new_exercise_log_path, class: 'add-log-button exercise-button'
+
+class NewLogButtonComponent
+  # include ActionView::Helpers::TagHelper
+
+  def initialize(log_klass:, text: nil, path:, method: :get, classes: nil)
+    @log_klass = log_klass
+    @text = text || decorated_log.display_name
+    @path = path
+    @method = method
+    @classes = classes
+  end
+
+  def render
+    ActionController::Base.helpers.link_to(button_text, @path, method: @method, class: computed_classes)
+  end
+
+  private
+
+  def button_text
+    MaterialIconComponent.new(icon: decorated_log.icon_name, size: :large).render + "<br>+#{@text}".html_safe
+  end
+
+  def decorated_log
+    @decorated_log ||= @log_klass.new.decorate
+  end
+
+  def computed_classes
+    "add-log-button #{decorated_log.css_name}-button"
+  end
+end

--- a/app/views/buttons/_new_exercise_log.html.erb
+++ b/app/views/buttons/_new_exercise_log.html.erb
@@ -1,1 +1,0 @@
-<%= link_to MaterialIcon.new(icon: ExerciseLog.new.decorate.icon_name, size: :large).render + '<br>+Exercise'.html_safe, new_exercise_log_path, class: 'add-log-button exercise-button' %>

--- a/app/views/buttons/_new_pain_log.html.erb
+++ b/app/views/buttons/_new_pain_log.html.erb
@@ -1,1 +1,0 @@
-<%= link_to MaterialIcon.new(icon: PainLog.new.decorate.icon_name, size: :large).render + '<br>+Pain'.html_safe, new_pain_log_path, class: 'add-log-button pain-button' %>

--- a/app/views/buttons/_new_pt_session_log.html.erb
+++ b/app/views/buttons/_new_pt_session_log.html.erb
@@ -1,1 +1,0 @@
-<%= link_to MaterialIcon.new(icon: PtSessionLog.new.decorate.icon_name, size: :large).render + '<br>+PT'.html_safe, new_pt_session_log_path, class: 'add-log-button therapy-button' %>

--- a/app/views/buttons/_new_slit_log.html.erb
+++ b/app/views/buttons/_new_slit_log.html.erb
@@ -1,1 +1,0 @@
-<%= link_to MaterialIcon.new(icon: SlitLog.new.decorate.icon_name, size: :large).render + '<br>+SLIT'.html_safe, quick_log_create_path, method: :post, class: 'add-log-button slit-button' %>

--- a/app/views/exercise_logs/index.html.erb
+++ b/app/views/exercise_logs/index.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= NewLogButtonComponent.new(log_klass: ExerciseLog, path: new_exercise_log_path).render %>
+  <%= NewLogButtonComponent.new(log_klass: ExerciseLog).render %>
 </header>
 
 <% @logs.each do |exercise_log| %>

--- a/app/views/exercise_logs/index.html.erb
+++ b/app/views/exercise_logs/index.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= render 'buttons/new_exercise_log' %>
+  <%= NewLogButtonComponent.new(log_klass: ExerciseLog, path: new_exercise_log_path).render %>
 </header>
 
 <% @logs.each do |exercise_log| %>

--- a/app/views/logs/_log_component.html.erb
+++ b/app/views/logs/_log_component.html.erb
@@ -2,7 +2,7 @@
   <a href="<%= edit_path %>">
     <div class="card--padding-clear flex">
       <div class="card--icon-container background-color-<%= log.css_name %> <%= 'background-color-error' if error_condition %>">
-        <%= MaterialIcon.new(icon: log.icon_name, size: :medium).render %>
+        <%= MaterialIconComponent.new(icon: log.icon_name, size: :medium).render %>
       </div>
       <div class='card-body'>
         <%= log_content %>

--- a/app/views/logs/_log_header.html.erb
+++ b/app/views/logs/_log_header.html.erb
@@ -1,6 +1,6 @@
 <header class='flex justify-between log-type-<%= log.css_name %>'>
   <h5 class='card-title'><%= format_datetime(log.occurred_at) if log.persisted? %></h5>
   <div class="header--icon-container background-color-<%= log.css_name %>">
-    <%= MaterialIcon.new(icon: log.icon_name, size: :medium).render %>
+    <%= MaterialIconComponent.new(icon: log.icon_name, size: :medium).render %>
   </div>
 </header>

--- a/app/views/pain_logs/index.html.erb
+++ b/app/views/pain_logs/index.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= render 'buttons/new_pain_log' %>
+  <%= NewLogButtonComponent.new(log_klass: PainLog, path: new_pain_log_path).render %>
 </header>
 
 <%= form_tag(pain_logs_path, method: 'get', id: 'filter-form' ) do %>

--- a/app/views/pain_logs/index.html.erb
+++ b/app/views/pain_logs/index.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= NewLogButtonComponent.new(log_klass: PainLog, path: new_pain_log_path).render %>
+  <%= NewLogButtonComponent.new(log_klass: PainLog).render %>
 </header>
 
 <%= form_tag(pain_logs_path, method: 'get', id: 'filter-form' ) do %>

--- a/app/views/pt_session_logs/index.html.erb
+++ b/app/views/pt_session_logs/index.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= render 'buttons/new_pt_session_log' %>
+  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT', path: new_pt_session_log_path).render %>
 </header>
 
 <% @logs.each do |pt_session_log| %>

--- a/app/views/pt_session_logs/index.html.erb
+++ b/app/views/pt_session_logs/index.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT', path: new_pt_session_log_path).render %>
+  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT').render %>
 </header>
 
 <% @logs.each do |pt_session_log| %>

--- a/app/views/shared/_add_log_buttons.html.erb
+++ b/app/views/shared/_add_log_buttons.html.erb
@@ -1,6 +1,6 @@
 <header class='add-log-buttons-container'>
   <%= NewLogButtonComponent.new(log_klass: SlitLog, text: 'SLIT', path: quick_log_create_path, method: :post).render if current_user.enable_slit_tracking %>
-  <%= NewLogButtonComponent.new(log_klass: PainLog, path: new_pain_log_path).render %>
-  <%= NewLogButtonComponent.new(log_klass: ExerciseLog, path: new_exercise_log_path).render %>
-  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT', path: new_pt_session_log_path).render %>
+  <%= NewLogButtonComponent.new(log_klass: PainLog).render %>
+  <%= NewLogButtonComponent.new(log_klass: ExerciseLog).render %>
+  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT').render %>
 </header>

--- a/app/views/shared/_add_log_buttons.html.erb
+++ b/app/views/shared/_add_log_buttons.html.erb
@@ -1,6 +1,6 @@
 <header class='add-log-buttons-container'>
-  <%= render 'buttons/new_slit_log' if current_user.enable_slit_tracking %>
-  <%= render 'buttons/new_pain_log' %>
-  <%= render 'buttons/new_exercise_log' %>
-  <%= render 'buttons/new_pt_session_log' %>
+  <%= NewLogButtonComponent.new(log_klass: SlitLog, text: 'SLIT', path: quick_log_create_path, method: :post).render if current_user.enable_slit_tracking %>
+  <%= NewLogButtonComponent.new(log_klass: PainLog, path: new_pain_log_path).render %>
+  <%= NewLogButtonComponent.new(log_klass: ExerciseLog, path: new_exercise_log_path).render %>
+  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT', path: new_pt_session_log_path).render %>
 </header>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-sm navbar-light bg-light">
-  <%= link_to MaterialIcon.new(icon: 'clinical_notes', title: 'Therapy Tracker', weight: :normal).render, root_url, class: 'navbar-logo' %>
+  <%= link_to MaterialIconComponent.new(icon: 'clinical_notes', title: 'Therapy Tracker', weight: :normal).render, root_url, class: 'navbar-logo' %>
   <%= link_to 'TherapyTracker', root_url, class: 'navbar-brand' %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag(url, method: 'get', id: 'search-form' ) do %>
   <div class="col-xs-12">
-    <%= MaterialIcon.new(icon: 'search', classes: 'search-icon').render %>
+    <%= MaterialIconComponent.new(icon: 'search', classes: 'search-icon').render %>
     <%= text_field_tag :search, params[:search], placeholder: 'Search', class: 'form-control form-control-sm' %>
   </div>
 <% end %>

--- a/app/views/slit_logs/index.html.erb
+++ b/app/views/slit_logs/index.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= render 'buttons/new_slit_log' %>
+  <%= NewLogButtonComponent.new(log_klass: SlitLog, text: 'SLIT', path: quick_log_create_path, method: :post).render if current_user.enable_slit_tracking %>
 </header>
 <!-- TODO: build out search form
 <%= form_tag(slit_logs_path, method: 'get', id: 'filter-form' ) do %>


### PR DESCRIPTION
## Related Issues & PRs
Closes #791

## Problems Solved
* renames `MaterialIcon` to `MaterialIconComponent` to embrace its componenty nature
* crates new `NewLogButtonComponent`
* each log type had its own partial for a button that is used on the home index page as well as each respective log indexes
* the new component takes a log class and builds a "new log" button for that class
* leverages rails magic plus decorator data to build custom buttons automagically

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
