### PR TITLE
Add enable_pt_session_tracking to users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,6 +26,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:enable_slit_tracking)
+    params.require(:user).permit(:enable_slit_tracking, :enable_pt_session_tracking)
   end
 end

--- a/app/views/pt_session_logs/index.html.erb
+++ b/app/views/pt_session_logs/index.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT').render %>
+  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT').render if current_user.enable_pt_session_tracking %>
 </header>
 
 <% @logs.each do |pt_session_log| %>

--- a/app/views/shared/_add_log_buttons.html.erb
+++ b/app/views/shared/_add_log_buttons.html.erb
@@ -2,5 +2,5 @@
   <%= NewLogButtonComponent.new(log_klass: SlitLog, text: 'SLIT', path: quick_log_create_path, method: :post).render if current_user.enable_slit_tracking %>
   <%= NewLogButtonComponent.new(log_klass: PainLog).render %>
   <%= NewLogButtonComponent.new(log_klass: ExerciseLog).render %>
-  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT').render %>
+  <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT').render if current_user.enable_pt_session_tracking %>
 </header>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -6,7 +6,7 @@
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <%= link_to '+ Exercise Log', new_exercise_log_path, class: 'dropdown-item' %>
       <%= link_to '+ Pain Log', new_pain_log_path, class: 'dropdown-item' %>
-      <%= link_to '+ PT Session', new_pt_session_log_path, class: 'dropdown-item' %>
+      <%= link_to '+ PT Session', new_pt_session_log_path, class: 'dropdown-item' if current_user.enable_pt_session_tracking %>
       <%= link_to '+ SLIT Log', new_slit_log_path, class: 'dropdown-item' if current_user.enable_slit_tracking %>
     </div>
   </li>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,6 +10,11 @@
     <label class="mb-0 inline">Enable SLIT Therapy Tracking</label>
   </div>
 
+  <div class='field'>
+    <%= form.check_box :enable_pt_session_tracking %>
+    <label class="mb-0 inline">Enable Physical Therapy Tracking</label>
+  </div>
+
   <div class='mt-3 mb-3'>
     <%= form.submit 'Submit', class: button_class('success') %>
   </div>

--- a/db/migrate/20240331195553_add_enable_pt_session_tracking_to_users.rb
+++ b/db/migrate/20240331195553_add_enable_pt_session_tracking_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddEnablePtSessionTrackingToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :enable_pt_session_tracking, :boolean, default: :false
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_17_151929) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_31_195553) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -175,6 +175,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_17_151929) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "enable_slit_tracking", default: false
+    t.boolean "enable_pt_session_tracking", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     password { 'password' }
     password_confirmation { 'password' }
     enable_slit_tracking { false }
+    enable_pt_session_tracking { false }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe User, type: :model do
                                last_name
                                admin
                                enable_slit_tracking
-                               created_at updated_at]
+                               enable_pt_session_tracking
+                               created_at
+                               updated_at]
       actual_attributes = build(:user).attributes.keys
 
       expect(actual_attributes).to match_array(expected_attributes)


### PR DESCRIPTION
## Problems Solved
* if a user is not currently doing physical therapy, they do not need a button to log a session
* adds config to user settings to enable/disable pt session tracking
* conditionally displays "add" buttons based on config
* config set to "false" by default

## Things Learned
* this is heckin easy to do since i aldrad did it for slit tracking. i think i banged this out in 8 minutes.

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
