### PR TITLE
Add today to slit logs

### DIFF
--- a/app/helpers/logs_helper.rb
+++ b/app/helpers/logs_helper.rb
@@ -3,7 +3,7 @@
 module LogsHelper
   def format_datetime(datetime)
     # log.datetime.strftime("%a %m/%d/%y at %I:%M %p in %Z")
-    datetime.strftime('%a %m/%d/%y at %I:%M %p')
+    datetime.strftime('%a %m/%d/%y at %I:%M%p')
   end
 
   def format_time_today_at(datetime)

--- a/app/helpers/logs_helper.rb
+++ b/app/helpers/logs_helper.rb
@@ -3,7 +3,11 @@
 module LogsHelper
   def format_datetime(datetime)
     # log.datetime.strftime("%a %m/%d/%y at %I:%M %p in %Z")
-    datetime.strftime('%a %m/%d/%y at %I:%M%p')
+    datetime.strftime('%a %m/%d/%y at %I:%M %p')
+  end
+
+  def format_time_today_at(datetime)
+    datetime.strftime('Today at %I:%M %p')
   end
 
   def last_log(kollection, attr)

--- a/app/views/slit_logs/_slit_log.html.erb
+++ b/app/views/slit_logs/_slit_log.html.erb
@@ -2,7 +2,9 @@
   <% if slit_log.dose_skipped? %>
     <h5 class='card-title color-error'>SLIT Dose SKIPPED: <%= slit_log.occurred_at.strftime('%a %m/%d/%y') %></h5>
   <% else %>
-    <h5 class='card-title color-slit'>SLIT Dose Taken: <%= format_datetime(slit_log.occurred_at) %></h5>
+    <h5 class='card-title color-slit'>
+      SLIT Dose Taken: <%= slit_log.occurred_at.to_date == Date.current ? format_time_today_at(slit_log.occurred_at) : format_datetime(slit_log.occurred_at) %>
+    </h5>
   <% end %>
   <p class="card-text">
     <%= slit_log.dose_skipped? ? 'Skipped Dose' : 'Took drops' %>

--- a/spec/helpers/logs_helper_spec.rb
+++ b/spec/helpers/logs_helper_spec.rb
@@ -4,9 +4,18 @@ require 'rails_helper'
 
 RSpec.describe LogsHelper, type: :helper do
   describe 'format_datetime' do
+    let(:current_datetime) { 'Sat, 23 Mar 2019 14:15:00 -0400'.to_datetime }
+
     it 'should format time' do
-      log = build(:exercise_log)
-      expect(helper.format_datetime(log.occurred_at)).to eq('Sat 03/23/19 at 02:08 PM')
+      expect(helper.format_datetime(current_datetime)).to eq('Sat 03/23/19 at 02:15 PM')
+    end
+  end
+
+  describe 'format_time_today_at' do
+    let(:current_datetime) { 'Mon, 01 Apr 2024 08:15:00 -0400'.to_datetime }
+
+    it 'should format time' do
+      expect(helper.format_time_today_at(current_datetime)).to eq('Today at 08:15 AM')
     end
   end
 

--- a/spec/helpers/logs_helper_spec.rb
+++ b/spec/helpers/logs_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe LogsHelper, type: :helper do
   describe 'format_datetime' do
     it 'should format time' do
       log = build(:exercise_log)
-      expect(helper.format_datetime(log.occurred_at)).to eq('Sat 03/23/19 at 02:08PM')
+      expect(helper.format_datetime(log.occurred_at)).to eq('Sat 03/23/19 at 02:08 PM')
     end
   end
 

--- a/spec/helpers/logs_helper_spec.rb
+++ b/spec/helpers/logs_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LogsHelper, type: :helper do
     let(:current_datetime) { 'Sat, 23 Mar 2019 14:15:00 -0400'.to_datetime }
 
     it 'should format time' do
-      expect(helper.format_datetime(current_datetime)).to eq('Sat 03/23/19 at 02:15 PM')
+      expect(helper.format_datetime(current_datetime)).to eq('Sat 03/23/19 at 02:15PM')
     end
   end
 


### PR DESCRIPTION
## Problems Solved
* since the app is on pooled dynos, it is sometimes hard to tell if the quick log worked.
* i don't always know the date first thing in the morning
* this PR replaces the date with "today" when the log date is today
<img width="539" alt="Screenshot 2024-04-17 at 9 09 21 AM" src="https://github.com/lortza/therapy_tracker/assets/8680712/9669c1f3-9ea7-4067-9b8a-cc18b5c4e7c0">

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
