### PR TITLE
Add start and end dates to SLIT Report

### DIFF
--- a/app/assets/stylesheets/pagination_links.scss
+++ b/app/assets/stylesheets/pagination_links.scss
@@ -32,3 +32,7 @@
     color: darken($brand-main, 5%);
   }
 }
+
+@media print {
+  .pagination { display: none; }
+}

--- a/app/controllers/slit_log_reports_controller.rb
+++ b/app/controllers/slit_log_reports_controller.rb
@@ -2,14 +2,21 @@
 
 class SlitLogReportsController < ApplicationController
   def index
-    report_record_limit = 90
-    @index_to_prompt_calling = 45
-    logs = current_user.slit_logs
-                       .where(occurred_at: report_record_limit.days.ago..Time.current)
+    start_date = search_params[:start_date].to_date.beginning_of_day
+    end_date = search_params[:end_date].to_date.end_of_day
+    logs = current_user.slit_logs.where(occurred_at: start_date..end_date)
                        .order(occurred_at: :asc)
-                       .limit(report_record_limit)
-                       .paginate(page: params[:page], per_page: 10)
+                       .paginate(page: params[:page], per_page: SlitLogReport::RECORD_LIMIT)
 
     @logs = SlitLogDecorator.decorate_collection(logs)
+  end
+
+  def new
+  end
+
+  private
+
+  def search_params
+    params.permit(:start_date, :end_date)
   end
 end

--- a/app/controllers/slit_log_reports_controller.rb
+++ b/app/controllers/slit_log_reports_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SlitLogReportsController < ApplicationController
+  def index
+    report_record_limit = 90
+    @index_to_prompt_calling = 45
+    logs = current_user.slit_logs
+                       .where(occurred_at: report_record_limit.days.ago..Time.current)
+                       .order(occurred_at: :asc)
+                       .limit(report_record_limit)
+                       .paginate(page: params[:page], per_page: 10)
+
+    @logs = SlitLogDecorator.decorate_collection(logs)
+  end
+end

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -59,17 +59,6 @@ class SlitLogsController < ApplicationController
     end
   end
 
-  def report
-    report_record_limit = 90
-    @index_to_prompt_calling = 45
-    logs = current_user.slit_logs
-                       .where(occurred_at: report_record_limit.days.ago..Time.current)
-                       .order(occurred_at: :asc)
-                       .limit(report_record_limit)
-
-    @logs = SlitLogDecorator.decorate_collection(logs)
-  end
-
   private
 
   def set_slit_log

--- a/app/models/slit_log.rb
+++ b/app/models/slit_log.rb
@@ -4,6 +4,4 @@ class SlitLog < ApplicationRecord
   belongs_to :user
 
   validates :occurred_at, presence: true
-
-  DOSE_TO_PLACE_ORDER = 60
 end

--- a/app/models/slit_log_report.rb
+++ b/app/models/slit_log_report.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SlitLogReport
+  RECORD_LIMIT = 90
+  DOSE_TO_PLACE_ORDER = 60
+
+
+  class << self
+    def default_start_date
+      Date.current - RECORD_LIMIT.days
+    end
+
+    def default_end_date
+      Date.current
+    end
+
+    def place_order_index
+      DOSE_TO_PLACE_ORDER
+    end
+  end
+end

--- a/app/models/slit_log_report.rb
+++ b/app/models/slit_log_report.rb
@@ -4,7 +4,6 @@ module SlitLogReport
   RECORD_LIMIT = 90
   DOSE_TO_PLACE_ORDER = 60
 
-
   class << self
     def default_start_date
       Date.current - RECORD_LIMIT.days

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,10 @@ class User < ApplicationRecord
   scope :with_slit_enabled, -> { where(enable_slit_tracking: true) }
 
   def full_name
-    "#{first_name} #{last_name}"
+    [first_name.presence, last_name.presence].compact.join(' ')
+  end
+
+  def name_or_email
+    full_name.presence || email
   end
 end

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -32,7 +32,7 @@
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <%= link_to 'Pain Stats by Body Part', stats_path, class: 'dropdown-item' %>
       <%= link_to 'Charts', charts_path, class: 'dropdown-item' %>
-      <%= link_to 'SLIT Logs for Print', slit_log_reports_path, class: 'dropdown-item' if current_user.enable_slit_tracking %>
+      <%= link_to 'SLIT Logs for Print', new_slit_log_report_path, class: 'dropdown-item' if current_user.enable_slit_tracking %>
       <div class='dropdown-divider'></div>
       <%= link_to 'Exercise Logs', exercise_logs_path, class: 'dropdown-item' %>
       <%= link_to 'Pain Logs', pain_logs_path, class: 'dropdown-item' %>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -32,7 +32,7 @@
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <%= link_to 'Pain Stats by Body Part', stats_path, class: 'dropdown-item' %>
       <%= link_to 'Charts', charts_path, class: 'dropdown-item' %>
-      <%= link_to 'SLIT Logs for Print', slit_report_path, class: 'dropdown-item' if current_user.enable_slit_tracking %>
+      <%= link_to 'SLIT Logs for Print', slit_log_reports_path, class: 'dropdown-item' if current_user.enable_slit_tracking %>
       <div class='dropdown-divider'></div>
       <%= link_to 'Exercise Logs', exercise_logs_path, class: 'dropdown-item' %>
       <%= link_to 'Pain Logs', pain_logs_path, class: 'dropdown-item' %>

--- a/app/views/slit_log_reports/index.html.erb
+++ b/app/views/slit_log_reports/index.html.erb
@@ -32,3 +32,4 @@
   <% end %>
 </div>
 
+<%= will_paginate @logs, page_links: false, class: "pagination mt-3 mb-0" %>

--- a/app/views/slit_log_reports/index.html.erb
+++ b/app/views/slit_log_reports/index.html.erb
@@ -1,5 +1,5 @@
 <h2>Sublingual Immunotherapy Patient Documentation</h2>
-<p>Maintenance Dosage log for patient <%= current_user.email %> from <%= @logs.first.occurred_at.strftime('%m/%d/%y') %> to <%= @logs.last.occurred_at.strftime('%m/%d/%y') %></p>
+<p>Maintenance Dosage log for patient <%= current_user.name_or_email %> from <%= @logs.first.occurred_at.strftime('%m/%d/%y') %> to <%= @logs.last.occurred_at.strftime('%m/%d/%y') %></p>
 <p><strong>NB</strong> = started new bottle | <strong>SKIPPED</strong> = drops not taken for date | <strong>CALL</strong> = Call 336-659-4814 to order more drops</p>
 
 <div class='slit-report-data-container mt-4'>
@@ -21,8 +21,8 @@
         <span><%= log.occurred_at.strftime('%a %m/%d/%y at %I:%M%p') %></span>
       <% end %>
 
-      <% if index == SlitLog::DOSE_TO_PLACE_ORDER %>
-        <span class="<%= 'highlight-yellow' if index == @index_to_prompt_calling %>"><strong>CALL</strong></span>
+      <% if index == SlitLogReport.place_order_index %>
+        <span class="<%= 'highlight-yellow' %>"><strong>CALL</strong></span>
       <% end %>
 
       <% if log.started_new_bottle? %>

--- a/app/views/slit_log_reports/new.html.erb
+++ b/app/views/slit_log_reports/new.html.erb
@@ -1,0 +1,16 @@
+<h2>SLIT Log Report</h2>
+<p>Enter date range for report. Form defaults to the past <%= pluralize(SlitLogReport::RECORD_LIMIT, 'day') %>.</p>
+<%= form_with(url: slit_log_reports_path, method: :get) do |f| %>
+  <div class='field'>
+    <%= f.label :start_date, 'Start Date' %>
+    <%= f.date_field :start_date,  value: SlitLogReport.default_start_date, class: 'form-control form-control-sm' %>
+  </div>
+  <div class='field'>
+    <%= f.label :end_date, 'End Date' %>
+    <%= f.date_field :end_date, value: SlitLogReport.default_end_date, class: 'form-control form-control-sm' %>
+  </div>
+  <div class='mt-3 mb-3'>
+    <%= f.submit 'Submit', class: button_class('success') %>
+  </div>
+<% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,5 +32,5 @@ Rails.application.routes.draw do
   resources :slit_logs
   post '/quick_log_create', to: 'slit_logs#quick_log_create'
 
-  resources :slit_log_reports, only: [:index]
+  resources :slit_log_reports, only: [:index, :new]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,5 +31,6 @@ Rails.application.routes.draw do
 
   resources :slit_logs
   post '/quick_log_create', to: 'slit_logs#quick_log_create'
-  get '/slit_report', to: 'slit_logs#report'
+
+  resources :slit_log_reports, only: [:index]
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,8 +2,9 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:first_name) { |n| "firstname#{n}" }
-    sequence(:last_name) { |n| "lastname#{n}" }
+    sequence(:first_name) { "" }
+    sequence(:last_name) { "" }
+    # TODO: make email defailt to ""
     sequence(:email) { |n| "user#{n}@example.com" }
     password { 'password' }
     password_confirmation { 'password' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:first_name) { "" }
-    sequence(:last_name) { "" }
-    # TODO: make email defailt to ""
+    sequence(:first_name) { '' }
+    sequence(:last_name) { '' }
+    # TODO: make email defailt to ''
     sequence(:email) { |n| "user#{n}@example.com" }
     password { 'password' }
     password_confirmation { 'password' }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -59,5 +59,35 @@ RSpec.describe User, type: :model do
       user = build(:user, first_name: 'first', last_name: 'last')
       expect(user.full_name).to eq('first last')
     end
+
+    context 'when there is no first_name' do
+      it 'does not include extra spacing' do
+        user = build(:user, last_name: 'last')
+        expect(user.full_name).to eq('last')
+      end
+    end
+
+    context 'when there is no last_name' do
+      it 'does not include extra spacing' do
+        user = build(:user, first_name: 'first')
+        expect(user.full_name).to eq('first')
+      end
+    end
+  end
+
+  describe '#name_or_email' do
+    context 'when there is no value for name' do
+      it 'displays the email address' do
+        user = build(:user, first_name: '', last_name: '', email: 'foo@email.com')
+        expect(user.name_or_email).to eq(user.email)
+      end
+    end
+
+    context 'when there is a value for name' do
+      it 'displays the full_name' do
+        user = build(:user, first_name: 'foo', email: 'foo@email.com')
+        expect(user.name_or_email).to eq(user.full_name)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Related Issues & PRs
Closes #812

## Problems Solved
* allows user to enter custom dates for SLIT log report
* defaults to past 90 days
* displays user full_name instead of just email on SLIT report
* fixes extra space bug on `user.full_name` 
* adds pagination to slit report (with buttons hidden for print)


## Things Learned
* `search_params[:start_date].to_date.beginning_of_day` you can only use `beginning_of_day` on a `Date` and not a `DateTime`. also queries didn't work without it.

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
