### PR TITLE
Convert quick logging from link_to to button_to

### DIFF
--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -17,6 +17,7 @@
 .flex { display: flex; }
 .inline-block { display: inline-block; }
 .justify-between { justify-content: space-between; }
+.w-100 { width: 100%; }
 
 // CORE
 .color-error { color: $red; }

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -35,10 +35,13 @@ class SlitLogsController < ApplicationController
   def quick_log_create
     @slit_log = current_user.slit_logs.new(occurred_at: Time.current)
 
-    if @slit_log.save!
-      redirect_to root_url
-    else
-      render :new
+    respond_to do |format|
+      if @slit_log.save!
+        # format.js
+        format.html { redirect_to root_url }
+      else
+        format.html { render :new }
+      end
     end
   end
 

--- a/app/views/shared/_add_log_buttons.html.erb
+++ b/app/views/shared/_add_log_buttons.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= NewLogButtonComponent.new(log_klass: SlitLog, text: 'SLIT', path: quick_log_create_path, method: :post).render if current_user.enable_slit_tracking %>
+  <%= render partial: 'shared/quick_log_button_to', locals: { text: 'SLIT', decorated_log: SlitLog.new.decorate, path: quick_log_create_path, use_js: false } if current_user.enable_slit_tracking?  %>
   <%= NewLogButtonComponent.new(log_klass: PainLog).render %>
   <%= NewLogButtonComponent.new(log_klass: ExerciseLog).render %>
   <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT').render if current_user.enable_pt_session_tracking %>

--- a/app/views/shared/_quick_log_button_to.html.erb
+++ b/app/views/shared/_quick_log_button_to.html.erb
@@ -1,0 +1,9 @@
+<%= button_to(MaterialIconComponent.new(
+      icon: decorated_log.icon_name,
+      size: :large
+    ).render + "<br>+#{text}".html_safe,
+    path,
+    remote: use_js,
+    form_class: "w-100", # applies to form
+    class: "add-log-button #{decorated_log.css_name}-button" # applies to button
+  )%>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -17,7 +17,7 @@
       Quick Log
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-      <%= link_to 'SLIT dose', quick_log_create_path, method: :post, class: 'dropdown-item' if current_user.enable_slit_tracking %>
+      <%= button_to 'SLIT dose', quick_log_create_path, method: :post, remote: false, class: 'dropdown-item' if current_user.enable_slit_tracking? %>
       <% current_user.pain_log_quick_form_values.order(name: :asc).each do |attr| %>
         <%= link_to attr.name, create_pain_log_from_quick_form_path(content: attr), method: :post, class: 'dropdown-item'  %>
       <% end %>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -19,7 +19,7 @@
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <%= button_to 'SLIT dose', quick_log_create_path, method: :post, remote: false, class: 'dropdown-item' if current_user.enable_slit_tracking? %>
       <% current_user.pain_log_quick_form_values.order(name: :asc).each do |attr| %>
-        <%= link_to attr.name, create_pain_log_from_quick_form_path(content: attr), method: :post, class: 'dropdown-item'  %>
+        <%= button_to attr.name, create_pain_log_from_quick_form_path(content: attr), class: 'dropdown-item'  %>
       <% end %>
     </div>
   </li>

--- a/app/views/slit_logs/index.html.erb
+++ b/app/views/slit_logs/index.html.erb
@@ -1,25 +1,6 @@
 <header class='add-log-buttons-container'>
-  <%= NewLogButtonComponent.new(log_klass: SlitLog, text: 'SLIT', path: quick_log_create_path, method: :post).render if current_user.enable_slit_tracking %>
+  <%= render partial: 'shared/quick_log_button_to', locals: { text: 'SLIT', decorated_log: SlitLog.new.decorate, path: quick_log_create_path, use_js: false } if current_user.enable_slit_tracking?  %>
 </header>
-<!-- TODO: build out search form
-<%= form_tag(slit_logs_path, method: 'get', id: 'filter-form' ) do %>
-  <div class='row'>
-    <div class='col-12 col-md-3 mb-2'>
-     probably do a between-dates search
-    </div>
-
-    <div class='col-12 col-md-3 mb-2'>
-      maybe do a new bottle search
-    </div>
-
-    <div class='col-12 col-md-3'>
-      <button type='submit' class='btn btn-secondary' style="width: 100%;">Submit</button>
-      <%= link_to 'Reset', slit_logs_path, class: 'ml-3 reset-link' %>
-    </div>
-  </div>
-<% end %>
-<hr>
--->
 
 <% @logs.each do |slit_log| %>
   <%= render partial: 'slit_log', locals: { slit_log: slit_log } %>


### PR DESCRIPTION
## Problems Solved
* uses proper `button_to` instead of `link_to` for `post`s made for quick logging 
* creates partial to handle post-style quick logging buttons
* related to #797

## Things Learned
* `button_to` is kind of sneaky to style. The `class` arg applies classes to the form `<button>`. The `form_class` arg supplies classes to the form itself.

## Due Diligence Checks
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
