### PR TITLE
Set app time zone

### DIFF
--- a/app/services/slit_log_skipped_dose_service.rb
+++ b/app/services/slit_log_skipped_dose_service.rb
@@ -18,7 +18,7 @@ class SlitLogSkippedDoseService
         )
         next unless no_log_for_user_yesterday?(user: user, yesterday: yesterday)
 
-        user.slit_logs.create(occurred_at: DateTime.yesterday, dose_skipped: true)
+        user.slit_logs.create(occurred_at: yesterday, dose_skipped: true)
       end
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,10 +21,12 @@ module TherapyTracker
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Eastern Time (US & Canada)'
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.active_support.cache_format_version = 7.1
   end
 end

--- a/spec/views/pain_logs/show.html.erb_spec.rb
+++ b/spec/views/pain_logs/show.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'pain_logs/show', type: :view do
     allow(view).to receive(:current_user).and_return(@user)
     render
     expect(rendered).to match(/user\d+@example.com/)
-    expect(rendered).to match(/03\/25\/19 at 08:15PM/)
+    expect(rendered).to match(%r{03/25/19 at 08:15PM})
     expect(rendered).to match(/body_part\d/)
     expect(rendered).to match(/\d/)
     expect(rendered).to match(/sample pain description/)

--- a/spec/views/pain_logs/show.html.erb_spec.rb
+++ b/spec/views/pain_logs/show.html.erb_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 RSpec.describe 'pain_logs/show', type: :view do
   before(:each) do
     @user = create(:user)
-    @pain_log = create(:pain_log, user_id: @user.id).decorate
+    @pain_log = create(:pain_log, occurred_at: '2019-03-25 20:15:37', user_id: @user.id).decorate
   end
 
   it 'renders attributes in <div>' do
     allow(view).to receive(:current_user).and_return(@user)
     render
     expect(rendered).to match(/user\d+@example.com/)
-    expect(rendered).to match(/2019-03-25 20:15:37 UTC/)
+    expect(rendered).to match(/03\/25\/19 at 08:15PM/)
     expect(rendered).to match(/body_part\d/)
     expect(rendered).to match(/\d/)
     expect(rendered).to match(/sample pain description/)


### PR DESCRIPTION
## Problems Solved
* fixes a bug where after upgrading to ruby 3.2.2 and rails 7.1 that the time zone for logging was not displaying correctly. 

## Due Diligence Checks
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
