### PR TITLE
Add automatic countdown timer for slit quick dose

### DIFF
--- a/app/assets/stylesheets/slit.scss
+++ b/app/assets/stylesheets/slit.scss
@@ -26,6 +26,28 @@
 
 .dose-skipped { color: $red; }
 
+.slit-timer-container {
+  text-align: center;
+  color: $brand-main;
+  border: .125em solid $brand-main;
+  border-radius: $bootstrap-card-border-radius;
+  background-color: $white;
+}
+
+.slit-timer-clock {
+  font-size: 5rem;
+  margin-top: 0;
+  line-height: normal;
+}
+
+.slit-timer-dismiss {
+  float: right;
+  &:hover {
+    color: darken($brand-main, 10%);
+    cursor: pointer;
+  }
+}
+
 // MEDIA QUERIES
 @media (max-width: 576px) {
   .slit-report-data-container {

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -33,11 +33,12 @@ class SlitLogsController < ApplicationController
   end
 
   def quick_log_create
-    @slit_log = current_user.slit_logs.new(occurred_at: Time.current)
+    slit_log = current_user.slit_logs.new(occurred_at: Time.current).decorate
 
     respond_to do |format|
-      if @slit_log.save!
-        # format.js
+      if slit_log.save!
+        @slit_log = slit_log.decorate
+        format.js
         format.html { redirect_to root_url }
       else
         format.html { render :new }

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -33,11 +33,10 @@ class SlitLogsController < ApplicationController
   end
 
   def quick_log_create
-    slit_log = current_user.slit_logs.new(occurred_at: Time.current).decorate
+    @slit_log = current_user.slit_logs.new(occurred_at: Time.current).decorate
 
     respond_to do |format|
-      if slit_log.save!
-        @slit_log = slit_log.decorate
+      if @slit_log.save!
         format.js
         format.html { redirect_to root_url }
       else

--- a/app/views/exercise_logs/_rep_counter_modal.html.erb
+++ b/app/views/exercise_logs/_rep_counter_modal.html.erb
@@ -1,34 +1,36 @@
 <!-- Modal -->
-<div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="repCounterModal" tabindex="-1" role="dialog" aria-labelledby="repCounterModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLabel">Rep Counter</h5>
+        <h5 class="modal-title" id="repCounterModalLabel">Rep Counter</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Dismiss">
           <span class="modal-dismiss">Close</span> <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body">
-
         <h3>
           <span id='begin-finished-indicator' class='hidden'></span>
         </h3>
         <div class='row'>
           <div class='col'>
             <p class='set-rep-row'>Set:<br>
-              <span id='set' class='counter-number-big'>0</span> of <%= @exercise_log.sets %>
+              <span id='set' class='counter-number-big'>0</span> of <%= sets %>
             </p>
           </div>
           <div class='col'>
-            <p class='set-rep-row'>Rep: (Hold for <%= @exercise_log.rep_length %>)<br>
-              <span id='rep' class='counter-number-big'>0</span> of <%= @exercise_log.reps %><br>
+            <p class='set-rep-row'>Rep: (Hold for <%= rep_length %>)<br>
+              <span id='rep' class='counter-number-big'>0</span> of <%= reps %><br>
             </p>
           </div>
-        </div> <!-- row -->
+        </div>
 
         <%= link_to '<i class="fas fa-play"></i> Start Timer'.html_safe, '#', id: 'start_button', class: button_class('success') %>
-        <%= link_to '<i class="fas fa-stop"></i> Stop & Reset '.html_safe, destination_url(@exercise_log, @pt_session_log), id: 'stop_button', class: button_class('danger pull-right') %>
+        <%= link_to '<i class="fas fa-stop"></i> Stop & Reset '.html_safe, cancel_url, id: 'stop_button', class: button_class('danger pull-right') %>
 
+        <script>
+          counter(<%= sets %>, <%= reps %>, <%= rep_length %>)
+        </script>
       </div><!-- modal body -->
     </div>
   </div>

--- a/app/views/exercise_logs/show.html.erb
+++ b/app/views/exercise_logs/show.html.erb
@@ -31,13 +31,11 @@
 
 
 <!-- Button trigger modal -->
-<button type='button' class='btn btn-warning btn-wide' data-toggle='modal' data-target='#exampleModal'>
+<button type='button' class='btn btn-warning btn-wide' data-toggle='modal' data-target='#repCounterModal'>
   <i class='far fa-stopwatch'></i> Launch Rep Counter
 </button>
 
-<%= render partial: 'exercise_logs/rep_counter_modal' %>
+<%= render partial: 'exercise_logs/rep_counter_modal', locals: { sets: @exercise_log.sets, reps: @exercise_log.reps, rep_length: @exercise_log.rep_length, cancel_url: destination_url(@exercise_log, @pt_session_log) } %>
 <%= new_exercise_log_button(@pt_session_log) %>
 
-<script>
-  counter(<%= @exercise_log.sets %>, <%= @exercise_log.reps %>, <%= @exercise_log.rep_length %>)
-</script>
+

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,6 +1,15 @@
 <% if @logs.present? %>
   <%= render partial: 'shared/add_log_buttons' %>
 
+  <div class='slit-timer-container hidden'>
+    <div id='js-slit-timer-dismiss' class="slit-timer-dismiss">
+      <%= MaterialIconComponent.new(icon: 'close', size: :large ).render %>
+    </div>
+    SLIT hold time remaining:
+    <%= link_to MaterialIconComponent.new(icon: 'timer_off', size: :medium ).render, logs_path, class: 'pull-right' %>
+    <div id='js-slit-timer' class='slit-timer-clock'></div>
+  </div>
+
   <% if last_homework %>
     <%= render partial: 'pt_session_logs/homework', locals: { homework: last_homework } %>
   <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -5,11 +5,13 @@
     <%= render partial: 'pt_session_logs/homework', locals: { homework: last_homework } %>
   <% end %>
 
-  <% @logs.each do |log| %>
-    <%= render log %>
-  <% end %>
-  <br>
-  <%= will_paginate @logs, :page_links => false %>
+  <div id='js-logs' class='mb-5'>
+    <% @logs.each do |log| %>
+      <%= render log %>
+    <% end %>
+  </div>
+
+  <%= will_paginate @logs, page_links: false %>
 
 <% else %>
   <%= render 'new_user_welcome' %>

--- a/app/views/shared/_add_log_buttons.html.erb
+++ b/app/views/shared/_add_log_buttons.html.erb
@@ -1,5 +1,5 @@
 <header class='add-log-buttons-container'>
-  <%= render partial: 'shared/quick_log_button_to', locals: { text: 'SLIT', decorated_log: SlitLog.new.decorate, path: quick_log_create_path, use_js: false } if current_user.enable_slit_tracking?  %>
+  <%= render partial: 'shared/quick_log_button_to', locals: { text: 'SLIT', decorated_log: SlitLog.new.decorate, path: quick_log_create_path, use_js: true } if current_user.enable_slit_tracking?  %>
   <%= NewLogButtonComponent.new(log_klass: PainLog).render %>
   <%= NewLogButtonComponent.new(log_klass: ExerciseLog).render %>
   <%= NewLogButtonComponent.new(log_klass: PtSessionLog, text: 'PT').render if current_user.enable_pt_session_tracking %>

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -17,7 +17,7 @@
       Quick Log
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-      <%= button_to 'SLIT dose', quick_log_create_path, method: :post, remote: false, class: 'dropdown-item' if current_user.enable_slit_tracking? %>
+      <%= button_to 'SLIT dose', quick_log_create_path, method: :post, remote: true, class: 'dropdown-item' if current_user.enable_slit_tracking? %>
       <% current_user.pain_log_quick_form_values.order(name: :asc).each do |attr| %>
         <%= button_to attr.name, create_pain_log_from_quick_form_path(content: attr), class: 'dropdown-item'  %>
       <% end %>

--- a/app/views/slit_logs/quick_log_create.js.erb
+++ b/app/views/slit_logs/quick_log_create.js.erb
@@ -1,8 +1,48 @@
-console.log('Hello');
-// debugger;
-
 // Append log to top of logs index
 document.getElementById('js-logs')
         .insertAdjacentHTML('afterbegin', "<%= escape_javascript(render partial: 'slit_log', locals: { slit_log: @slit_log }) %>");
 
-// Append timer to top of logs index
+// Start Timer
+const timerElement = document.getElementById('js-slit-timer');
+timerElement.innerHTML = 00 + ":" + 05;
+startTimer();
+
+function startTimer() {
+  timerElement.parentElement.classList.remove('hidden');
+  var startTime = timerElement.innerHTML;
+  var timeArray = startTime.split(/[:]+/);
+  var min = timeArray[0];
+  var sec = checkSecond((timeArray[1] - 1));
+  if (sec == 59) { min = min - 1 }
+  if (min < 0) {
+    completeTimer();
+    return
+  }
+
+  timerElement.innerHTML = min + ":" + sec;
+  console.log(min)
+  setTimeout(startTimer, 1000);
+}
+
+function checkSecond(sec) {
+  if (sec < 10 && sec >= 0) {sec = "0" + sec}; // add zero in front of numbers < 10
+  if (sec < 0) {sec = "59"};
+  return sec;
+}
+
+function completeTimer() {
+  const soundExerciseComplete = new Audio('/sounds/exercise_complete.m4a');
+  console.log(`Timer ended`)
+  //beginFinishedIndicator.textContent = 'Finished!';
+  //setDisplayer.textContent = 0;
+  //repDisplayer.textContent = 0;
+  soundExerciseComplete.play().catch(e => {
+    console.log(e);
+  });
+}
+
+const dismissButton = document.getElementById('js-slit-timer-dismiss');
+dismissButton.addEventListener('click', function (event) {
+  event.preventDefault;
+  timerElement.parentElement.classList.add('hidden');
+});

--- a/app/views/slit_logs/quick_log_create.js.erb
+++ b/app/views/slit_logs/quick_log_create.js.erb
@@ -33,9 +33,6 @@ function checkSecond(sec) {
 function completeTimer() {
   const soundExerciseComplete = new Audio('/sounds/exercise_complete.m4a');
   console.log(`Timer ended`)
-  //beginFinishedIndicator.textContent = 'Finished!';
-  //setDisplayer.textContent = 0;
-  //repDisplayer.textContent = 0;
   soundExerciseComplete.play().catch(e => {
     console.log(e);
   });

--- a/app/views/slit_logs/quick_log_create.js.erb
+++ b/app/views/slit_logs/quick_log_create.js.erb
@@ -1,0 +1,8 @@
+console.log('Hello');
+// debugger;
+
+// Append log to top of logs index
+document.getElementById('js-logs')
+        .insertAdjacentHTML('afterbegin', "<%= escape_javascript(render partial: 'slit_log', locals: { slit_log: @slit_log }) %>");
+
+// Append timer to top of logs index

--- a/app/views/slit_logs/quick_log_create.js.erb
+++ b/app/views/slit_logs/quick_log_create.js.erb
@@ -4,7 +4,7 @@ document.getElementById('js-logs')
 
 // Start Timer
 const timerElement = document.getElementById('js-slit-timer');
-timerElement.innerHTML = 00 + ":" + 05;
+timerElement.innerHTML = 02 + ":" + 00;
 startTimer();
 
 function startTimer() {


### PR DESCRIPTION
## Related Issues & PRs
Closes #797

## Problems Solved
* Allows for 1-touch logging and timer start
* No need for setting an external timer
* Sounds chime at end of timer for when you're not looking at your phone
* Allows for dismissing the timer early
* Allows for dismissing the timer when the timer has finished 

## Screenshots
<img width="380" alt="Screenshot 2024-04-24 at 7 57 48 PM" src="https://github.com/lortza/therapy_tracker/assets/8680712/07462715-1eb0-4f4d-aeda-736620cf99fb">

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
