### PR TITLE
Put SLIT and PT features behind user settings

### DIFF
--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,17 +1,19 @@
 <% if @logs.present? %>
   <%= render partial: 'shared/add_log_buttons' %>
 
-  <div class='slit-timer-container hidden'>
-    <div id='js-slit-timer-dismiss' class="slit-timer-dismiss hidden">
-      <%= MaterialIconComponent.new(icon: 'close', size: :large ).render %>
+  <% if current_user.enable_slit_tracking? %>
+    <div class='slit-timer-container hidden'>
+      <div id='js-slit-timer-dismiss' class="slit-timer-dismiss hidden">
+        <%= MaterialIconComponent.new(icon: 'close', size: :large ).render %>
+      </div>
+
+      SLIT hold time remaining:
+      <%= link_to MaterialIconComponent.new(icon: 'timer_off', size: :medium ).render, logs_path, id: 'js-slit-timer-cancel-btn', class: 'pull-right' %>
+      <div id='js-slit-timer' class='slit-timer-clock'></div>
     </div>
+  <% end %>
 
-    SLIT hold time remaining:
-    <%= link_to MaterialIconComponent.new(icon: 'timer_off', size: :medium ).render, logs_path, id: 'js-slit-timer-cancel-btn', class: 'pull-right' %>
-    <div id='js-slit-timer' class='slit-timer-clock'></div>
-  </div>
-
-  <% if last_homework %>
+  <% if current_user.enable_pt_session_tracking? && last_homework %>
     <%= render partial: 'pt_session_logs/homework', locals: { homework: last_homework } %>
   <% end %>
 


### PR DESCRIPTION
## Problems Solved
* only displays PT homework on logs index if the user has enabled PT session logging
* only displays SLIT timer on logs index if the user has enabled SLIT logging
* cleans up the html output and reduces opportunity for trying to query on `nil`

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
