### PR TITLE
Disable user sign-up

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,19 +1,21 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<%= link_to "Back", :back, class: "#{button_class('info')} pull-right" %>
+<h1>Edit <%= resource_name.to_s.humanize %></h1>
+
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= devise_error_messages! %>
 
-  <div class="field">
+  <div class="field mt-2">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
   </div>
 
-  <div class="field">
+  <div class="field mt-2">
     <%= f.label :first_name %>
     <%= f.text_field :first_name, class: 'form-control' %>
   </div>
 
-  <div class="field">
+  <div class="field mt-2">
     <%= f.label :last_name %>
     <%= f.text_field :last_name, class: 'form-control' %>
   </div>
@@ -22,26 +24,25 @@
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+  <div class="field mt-2">
+    <%= f.label :password %> <i class='text-muted'>(leave blank if you don't want to change it)</i><br />
     <%= f.password_field :password, autocomplete: "new-password", class: 'form-control' %>
     <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em class='text-muted'><%= @minimum_password_length %> characters minimum</em>
     <% end %>
   </div>
 
-  <div class="field">
+  <div class="field mt-2">
     <%= f.label :password_confirmation %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'form-control' %>
   </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+  <div class="field mt-2">
+    <%= f.label :current_password %> <i class='text-muted'>(we need your current password to confirm your changes)</i><br />
     <%= f.password_field :current_password, autocomplete: "current-password", class: 'form-control' %>
   </div>
 
-  <div class="actions">
+  <div class="actions mt-3">
     <%= f.submit "Update", class: button_class('success') %>
   </div>
 <% end %>
@@ -50,5 +51,3 @@
 <h4>Cancel my account</h4>
 
 <p>Unhappy? <%= button_to "Delete my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: button_class('danger') %></p>
-<hr>
-<%= link_to "Back", :back, class: button_class('info') %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,12 +3,12 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
   </div>
 
   <div class="field">
     <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %>
   </div>
 
   <% if devise_mapping.rememberable? -%>
@@ -19,7 +19,7 @@
   <% end -%>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "Log in", class: button_class('success') %>
   </div>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,12 @@
 
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  devise_for :users
+
+  # Clobber sign_up for now so no new users can sign up.
+  devise_for :users, path_names: {
+    sign_up: ''
+  }
+
   root to: 'logs#index'
 
   namespace :admin do


### PR DESCRIPTION
## Problems Solved
* disables user sign-up ability. this had been turned on because i had wanted access to the other devise registrations routes
* fancies up the devise sign in and edit settings pages with bootstrap styles

<img width="1143" alt="Screenshot 2024-05-14 at 7 18 28 PM" src="https://github.com/lortza/therapy_tracker/assets/8680712/81883f1d-eb0a-44d1-8fac-f249136326b1">


## Things Learned
* how to clobber a single devise route

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
