### PR TITLE
Add dose countdown

### DIFF
--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -33,7 +33,8 @@ class SlitLogsController < ApplicationController
   end
 
   def quick_log_create
-    @slit_log = current_user.slit_logs.new(occurred_at: Time.current).decorate
+    attrs = {occurred_at: Time.current, started_new_bottle: params[:started_new_bottle]}
+    @slit_log = current_user.slit_logs.new(attrs).decorate
 
     respond_to do |format|
       if @slit_log.save!

--- a/app/controllers/slit_logs_controller.rb
+++ b/app/controllers/slit_logs_controller.rb
@@ -33,7 +33,7 @@ class SlitLogsController < ApplicationController
   end
 
   def quick_log_create
-    attrs = {occurred_at: Time.current, started_new_bottle: params[:started_new_bottle]}
+    attrs = { occurred_at: Time.current, started_new_bottle: params[:started_new_bottle] }
     @slit_log = current_user.slit_logs.new(attrs).decorate
 
     respond_to do |format|

--- a/app/models/slit_log.rb
+++ b/app/models/slit_log.rb
@@ -12,13 +12,13 @@ class SlitLog < ApplicationRecord
   private
 
   def set_doses_remaining
-    return if self.doses_remaining.present?
+    return if doses_remaining.present?
 
     if started_new_bottle?
       self.doses_remaining = MAX_BOTTLE_DOSES
     else
       previous_balance = previous_log&.doses_remaining
-      return nil unless previous_balance.present?
+      return nil if previous_balance.blank?
 
       self.doses_remaining = calculate_doses_remaining(previous_balance)
     end
@@ -32,7 +32,7 @@ class SlitLog < ApplicationRecord
   def calculate_doses_remaining(previous_log_doses_remaining)
     if dose_skipped?
       previous_log_doses_remaining
-    elsif previous_log_doses_remaining > 0
+    elsif previous_log_doses_remaining.positive?
       previous_log_doses_remaining - 1
     else
       0

--- a/app/models/slit_log.rb
+++ b/app/models/slit_log.rb
@@ -12,6 +12,8 @@ class SlitLog < ApplicationRecord
   private
 
   def set_doses_remaining
+    return if self.doses_remaining.present?
+
     if started_new_bottle?
       self.doses_remaining = MAX_BOTTLE_DOSES
     else

--- a/app/models/slit_log.rb
+++ b/app/models/slit_log.rb
@@ -4,4 +4,36 @@ class SlitLog < ApplicationRecord
   belongs_to :user
 
   validates :occurred_at, presence: true
+
+  before_save :set_doses_remaining
+
+  MAX_BOTTLE_DOSES = 45
+
+  private
+
+  def set_doses_remaining
+    if started_new_bottle?
+      self.doses_remaining = MAX_BOTTLE_DOSES
+    else
+      previous_balance = previous_log&.doses_remaining
+      return nil unless previous_balance.present?
+
+      self.doses_remaining = calculate_doses_remaining(previous_balance)
+    end
+  end
+
+  def previous_log
+    current_stamp = DateTime.current
+    SlitLog.where('occurred_at < ?', current_stamp).order(occurred_at: :desc).first
+  end
+
+  def calculate_doses_remaining(previous_log_doses_remaining)
+    if dose_skipped?
+      previous_log_doses_remaining
+    elsif previous_log_doses_remaining > 0
+      previous_log_doses_remaining - 1
+    else
+      0
+    end
+  end
 end

--- a/app/views/shared/_session_nav.html.erb
+++ b/app/views/shared/_session_nav.html.erb
@@ -18,6 +18,7 @@
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <%= button_to 'SLIT dose', quick_log_create_path, method: :post, remote: true, class: 'dropdown-item' if current_user.enable_slit_tracking? %>
+      <%= button_to 'SLIT dose New Bottle', quick_log_create_path, params: {started_new_bottle: true}, method: :post, remote: true, class: 'dropdown-item' if current_user.enable_slit_tracking? %>
       <% current_user.pain_log_quick_form_values.order(name: :asc).each do |attr| %>
         <%= button_to attr.name, create_pain_log_from_quick_form_path(content: attr), class: 'dropdown-item'  %>
       <% end %>

--- a/spec/models/slit_log_spec.rb
+++ b/spec/models/slit_log_spec.rb
@@ -10,4 +10,70 @@ RSpec.describe SlitLog, type: :model do
   context 'validations' do
     it { should validate_presence_of(:occurred_at) }
   end
+
+  describe 'before_save actions' do
+    describe 'private: set_doses_remaining' do
+      before do
+        user = create(:user)
+        create(:slit_log, user: user, occurred_at: DateTime.current - 2.days, doses_remaining: previous_balance)
+      end
+
+      context 'when starting a new bottle' do
+        let(:slit_log) { build(:slit_log, started_new_bottle: true) }
+        let(:previous_balance) { nil }
+
+        it 'sets the doses_remaining to the default value' do
+          slit_log.send(:set_doses_remaining)
+          expect(slit_log.doses_remaining).to eq(SlitLog::MAX_BOTTLE_DOSES)
+        end
+      end
+
+      context "when a previous log's doses_remaining is not available" do
+        let(:slit_log) { build(:slit_log) }
+        let(:previous_balance) { nil }
+
+        it 'sets the doses_remaining to nil' do
+          slit_log.send(:set_doses_remaining)
+          expect(slit_log.doses_remaining).to be(nil)
+        end
+      end
+
+      context "when a previous log's doses_remaining is available" do
+        let(:slit_log) { build(:slit_log) }
+        let(:previous_balance) { 1 }
+
+        it 'calls calculate_doses_remaining' do
+          expect(slit_log).to receive(:calculate_doses_remaining)
+          slit_log.send(:set_doses_remaining)
+        end
+      end
+    end
+  end
+
+  describe 'private: #calculate_doses_remaining' do
+    context 'when the current log is a skipped dose' do
+      it "uses the previous log's value" do
+        previous_value = 5
+        expect(SlitLog.new(dose_skipped: true).send(:calculate_doses_remaining, previous_value)).to eq(previous_value)
+      end
+    end
+
+    context "when the previous log's value is greater than zero" do
+      it "returns the previous log's value minus 1" do
+        expect(SlitLog.new.send(:calculate_doses_remaining, 5)).to eq(4)
+      end
+    end
+
+    context "when the previous log's value is zero" do
+      it "returns 0" do
+        expect(SlitLog.new.send(:calculate_doses_remaining, 0)).to eq(0)
+      end
+    end
+
+    context "when the previous log's value is less than zero" do
+      it "returns 0" do
+        expect(SlitLog.new.send(:calculate_doses_remaining, -1)).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/models/slit_log_spec.rb
+++ b/spec/models/slit_log_spec.rb
@@ -75,13 +75,13 @@ RSpec.describe SlitLog, type: :model do
     end
 
     context "when the previous log's value is zero" do
-      it "returns 0" do
+      it 'returns 0' do
         expect(SlitLog.new.send(:calculate_doses_remaining, 0)).to eq(0)
       end
     end
 
     context "when the previous log's value is less than zero" do
-      it "returns 0" do
+      it 'returns 0' do
         expect(SlitLog.new.send(:calculate_doses_remaining, -1)).to eq(0)
       end
     end

--- a/spec/models/slit_log_spec.rb
+++ b/spec/models/slit_log_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe SlitLog, type: :model do
         create(:slit_log, user: user, occurred_at: DateTime.current - 2.days, doses_remaining: previous_balance)
       end
 
+      context 'when the new log contains a value for doses_remaining' do
+        let(:slit_log) { build(:slit_log, doses_remaining: 15) }
+        let(:previous_balance) { 30 }
+
+        it 'sets uses the existing doses_remaining value' do
+          slit_log.send(:set_doses_remaining)
+          expect(slit_log.doses_remaining).to eq(15)
+        end
+      end
+
       context 'when starting a new bottle' do
         let(:slit_log) { build(:slit_log, started_new_bottle: true) }
         let(:previous_balance) { nil }


### PR DESCRIPTION
## Related Issues & PRs
Closes #755

## Problems Solved
* indicates how many doses are left in the current bottle
* uses existing view logic
* allows user-entered value to persist (for backfilling purposes or non-standard bottle amts)
* sets value to default value when there is a new bottle
* adds new quick link for quick log with new bottle


## Things Learned
Passing params with a create path helper is not intuitive:
```
button_to 'SLIT dose New Bottle', quick_log_create_path, params: {started_new_bottle: true}, method: :post, remote: true, class: 'dropdown-item' if current_user.enable_slit_tracking?
```

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I have written new specs for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
