### PR TITLE
Remove "call" details from slit report

### DIFF
--- a/app/views/slit_log_reports/index.html.erb
+++ b/app/views/slit_log_reports/index.html.erb
@@ -3,7 +3,7 @@
 <% if @logs.any? %>
   from <%= @logs.first.occurred_at.strftime('%m/%d/%y') %> to <%= @logs.last.occurred_at.strftime('%m/%d/%y') %></p>
 <% end %>
-<p><strong>NB</strong> = started new bottle | <strong>SKIPPED</strong> = drops not taken for date | <strong>CALL</strong> = Call 336-659-4814 to order more drops</p>
+<p><strong>NB</strong> = started new bottle | <strong>SKIPPED</strong> = drops not taken for date</p>
 
 <div class='slit-report-data-container mt-4'>
   <% 3.times do %>
@@ -21,11 +21,7 @@
       <% if log.dose_skipped? %>
         <span><%= log.occurred_at.strftime('%a %m/%d/%y') %> <strong class="dose-skipped">SKIPPED</strong></span>
       <% else %>
-        <span><%= log.occurred_at.strftime('%a %m/%d/%y at %I:%M%p') %></span>
-      <% end %>
-
-      <% if index == SlitLogReport.place_order_index %>
-        <span class="<%= 'highlight-yellow' %>"><strong>CALL</strong></span>
+        <span><%= log.occurred_at.strftime('%a %m-%d-%y at %I:%M%P') %></span>
       <% end %>
 
       <% if log.started_new_bottle? %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,12 +14,16 @@ User.destroy_all
 
 
 #-------------------------------------------
-#            BUILD BASE CLASSES
+#            CREATE USER
 #-------------------------------------------
 puts 'Building Users'
-user = FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@example.com', admin: true)
-# user = User.first
-#------------------------------------------
+existing_user = User.find_by(email: 'admin@email.com', admin: true)
+user = existing_user.present? ? existing_user : FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@email.com', admin: true)
+
+
+#-------------------------------------------
+#            BUILD BASE CLASSES
+#-------------------------------------------
 puts 'Building Exercises'
 FactoryBot.create(:exercise, user_id: user.id, name: 'clam shells', description: 'lie on one side with legs bent at knees', default_per_side: true )
 FactoryBot.create(:exercise, user_id: user.id, name: 'wall slides', description: 'lie on side with body flat against wall. raise leg up, sliding heel againt wall.', default_per_side: true )
@@ -60,72 +64,75 @@ end
 
 #------------------------------------------
 puts '... Exercise Logs'
-  progress_notes = [
-    'generally feels more supported, but pain is still very present',
-    'feeling good this morning. hip cracked during exercise and that felt nice.',
-    'feels weaker than other side. Didn’t notice much of a difference after this session.',
-    'Went for a walk right afterwards. We did 1 little loop and i was not feeling much pain, so we did another small loop.',
-    'feels weaker than right also, hip is a little sore this morning in the joint. it doesn’t feel like workout sore.',
-    'still feels weaker than other side. weird. no muscle soreness from exercise.',
-    'feels weaker than other side also is a little sore this morning in the joint.'
-  ]
+progress_notes = [
+  'generally feels more supported, but pain is still very present',
+  'feeling good this morning. hip cracked during exercise and that felt nice.',
+  'feels weaker than other side. Didn’t notice much of a difference after this session.',
+  'Went for a walk right afterwards. We did 1 little loop and i was not feeling much pain, so we did another small loop.',
+  'feels weaker than right also, hip is a little sore this morning in the joint. it doesn’t feel like workout sore.',
+  'still feels weaker than other side. weird. no muscle soreness from exercise.',
+  'feels weaker than other side also is a little sore this morning in the joint.'
+]
 
-  LOG_MULTIPLIER.times do
-    FactoryBot.create(
-      :exercise_log,
-      user_id: user.id,
-      body_part_id: BodyPart.all.sample.id,
-      exercise_id: Exercise.all.sample.id,
-      occurred_at: generate_datetime,
-      progress_note: progress_notes.sample
-    )
+LOG_MULTIPLIER.times do
+  FactoryBot.create(
+    :exercise_log,
+    user_id: user.id,
+    body_part_id: BodyPart.all.sample.id,
+    exercise_id: Exercise.all.sample.id,
+    occurred_at: generate_datetime,
+    progress_note: progress_notes.sample
+  )
+end
+
+#------------------------------------------
+puts '... Pain Logs'
+LOG_MULTIPLIER.times do
+  FactoryBot.create(
+    :pain_log,
+    user_id: user.id,
+    body_part_id: BodyPart.all.sample.id,
+    pain_id: Pain.all.sample.id,
+    occurred_at: generate_datetime
+  )
+end
+
+#------------------------------------------
+puts '... Physical Therapy Session Logs'
+exercise_note_opts = [
+  'leveled up this time. used harder band. did one more set on most exercises',
+  'tried a new warmup this time. dr says flexibility is good, but need to do more. showed me 2 new stretches.',
+  'did strength testing for benchmarks. there is improvement since last week.',
+]
+
+homework_notes = [
+  'same as session',
+  'do regular exercises and incorporate in 1 or two extra sets or reps where you can',
+  'regular exercises plus add in an extra walk around the neighborhood',
+  'regular exercises plus add in an extra bike ride',
+  'try walking as fast as you can to see how far you can get before pain sets in'
+]
+
+LOG_MULTIPLIER.times do
+  pt_session_log = FactoryBot.create(
+    :pt_session_log,
+    user_id: user.id,
+    body_part_id: BodyPart.all.sample.id,
+    occurred_at: generate_datetime,
+    exercise_notes: exercise_note_opts.sample,
+    homework: homework_notes.sample
+  )
+
+  exercise_multiplier = (1..(Exercise.count)).to_a.sample
+
+  exercise_multiplier.times do
+    pt_session_log.homework_exercises << Exercise.all.sample
   end
 
-  #------------------------------------------
-  puts '... Pain Logs'
-  LOG_MULTIPLIER.times do
-    FactoryBot.create(
-      :pain_log,
-      user_id: user.id,
-      body_part_id: BodyPart.all.sample.id,
-      pain_id: Pain.all.sample.id,
-      occurred_at: generate_datetime
-    )
+  exercise_multiplier.times do
+    FactoryBot.create(:exercise_log, user_id: pt_session_log.user_id, pt_session_log_id: pt_session_log.id, exercise_id: Exercise.all.sample.id)
   end
+end
 
-  #------------------------------------------
-  puts '... Physical Therapy Session Logs'
-  exercise_note_opts = [
-    'leveled up this time. used harder band. did one more set on most exercises',
-    'tried a new warmup this time. dr says flexibility is good, but need to do more. showed me 2 new stretches.',
-    'did strength testing for benchmarks. there is improvement since last week.',
-  ]
-
-  homework_notes = [
-    'same as session',
-    'do regular exercises and incorporate in 1 or two extra sets or reps where you can',
-    'regular exercises plus add in an extra walk around the neighborhood',
-    'regular exercises plus add in an extra bike ride',
-    'try walking as fast as you can to see how far you can get before pain sets in'
-  ]
-
-  LOG_MULTIPLIER.times do
-    pt_session_log = FactoryBot.create(
-      :pt_session_log,
-      user_id: user.id,
-      body_part_id: BodyPart.all.sample.id,
-      occurred_at: generate_datetime,
-      exercise_notes: exercise_note_opts.sample,
-      homework: homework_notes.sample
-    )
-
-    exercise_multiplier = (1..(Exercise.count)).to_a.sample
-
-    exercise_multiplier.times do
-      pt_session_log.homework_exercises << Exercise.all.sample
-    end
-
-    exercise_multiplier.times do
-      FactoryBot.create(:exercise_log, user_id: pt_session_log.user_id, pt_session_log_id: pt_session_log.id, exercise_id: Exercise.all.sample.id)
-    end
-  end
+#------------------------------------------
+Rake::Task["db:seed:slit_logs"].invoke(user.id)

--- a/lib/tasks/seed/slit_logs.rake
+++ b/lib/tasks/seed/slit_logs.rake
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :seed do
+    desc 'Create SLIT Logs'
+    task :slit_logs, [:user_id] => [:environment] do |_task, args|
+      puts 'Removing all SLIT Logs'
+      SlitLog.destroy_all
+
+      puts 'Seeding SLIT Logs'
+      user_id = if args[:user_id].present?
+        args[:user_id]
+      else
+        existing_user = User.find_by(email: 'admin@email.com', admin: true)
+        existing_user.present? ? existing_user.id : FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@email.com', admin: true).id
+      end
+
+      LOG_MULTIPLIER = 90
+      start_date = DateTime.current - LOG_MULTIPLIER
+
+      LOG_MULTIPLIER.times do |i|
+        FactoryBot.create(
+          :slit_log,
+          user_id: user_id,
+          started_new_bottle:(i % 45 == 0),
+          dose_skipped: i != 0 && (i % 13 == 0),
+          occurred_at: (start_date + i + 1)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problems Solved
* The "CALL" indicator was not useful on the report, so i removed it
* Converts AM/PM to am/pm to make it easier to read
* adds seeds for slit logs to make browser testing this feature easier

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [ ] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
