### PR TITLE
Separate seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,7 @@ puts 'Destroying all assets'
 ExerciseLog.destroy_all
 PainLog.destroy_all
 PtSessionLog.destroy_all
+SlitLog.destroy_all
 Pain.destroy_all
 BodyPart.destroy_all
 Exercise.destroy_all
@@ -38,7 +39,6 @@ body_part_names.each do |body_part_name|
   FactoryBot.create(:body_part, user_id: user.id, name: body_part_name)
 end
 
-body_part = BodyPart.first
 
 #------------------------------------------
 puts 'Building Pains'
@@ -48,91 +48,12 @@ pain_names.each do |pain_name|
   FactoryBot.create(:pain, user_id: user.id, name: pain_name)
 end
 
-pain = Pain.all.sample
-
 
 #-------------------------------------------
 #              BUILD LOGS
 #-------------------------------------------
 puts 'Building Logs'
-LOG_MULTIPLIER = 30
-
-def generate_datetime
-  h = rand(6..20)
-  Faker::Date.between(from: 1.month.ago, to: Date.today).to_datetime + h.hours
-end
-
-#------------------------------------------
-puts '... Exercise Logs'
-progress_notes = [
-  'generally feels more supported, but pain is still very present',
-  'feeling good this morning. hip cracked during exercise and that felt nice.',
-  'feels weaker than other side. Didn’t notice much of a difference after this session.',
-  'Went for a walk right afterwards. We did 1 little loop and i was not feeling much pain, so we did another small loop.',
-  'feels weaker than right also, hip is a little sore this morning in the joint. it doesn’t feel like workout sore.',
-  'still feels weaker than other side. weird. no muscle soreness from exercise.',
-  'feels weaker than other side also is a little sore this morning in the joint.'
-]
-
-LOG_MULTIPLIER.times do
-  FactoryBot.create(
-    :exercise_log,
-    user_id: user.id,
-    body_part_id: BodyPart.all.sample.id,
-    exercise_id: Exercise.all.sample.id,
-    occurred_at: generate_datetime,
-    progress_note: progress_notes.sample
-  )
-end
-
-#------------------------------------------
-puts '... Pain Logs'
-LOG_MULTIPLIER.times do
-  FactoryBot.create(
-    :pain_log,
-    user_id: user.id,
-    body_part_id: BodyPart.all.sample.id,
-    pain_id: Pain.all.sample.id,
-    occurred_at: generate_datetime
-  )
-end
-
-#------------------------------------------
-puts '... Physical Therapy Session Logs'
-exercise_note_opts = [
-  'leveled up this time. used harder band. did one more set on most exercises',
-  'tried a new warmup this time. dr says flexibility is good, but need to do more. showed me 2 new stretches.',
-  'did strength testing for benchmarks. there is improvement since last week.',
-]
-
-homework_notes = [
-  'same as session',
-  'do regular exercises and incorporate in 1 or two extra sets or reps where you can',
-  'regular exercises plus add in an extra walk around the neighborhood',
-  'regular exercises plus add in an extra bike ride',
-  'try walking as fast as you can to see how far you can get before pain sets in'
-]
-
-LOG_MULTIPLIER.times do
-  pt_session_log = FactoryBot.create(
-    :pt_session_log,
-    user_id: user.id,
-    body_part_id: BodyPart.all.sample.id,
-    occurred_at: generate_datetime,
-    exercise_notes: exercise_note_opts.sample,
-    homework: homework_notes.sample
-  )
-
-  exercise_multiplier = (1..(Exercise.count)).to_a.sample
-
-  exercise_multiplier.times do
-    pt_session_log.homework_exercises << Exercise.all.sample
-  end
-
-  exercise_multiplier.times do
-    FactoryBot.create(:exercise_log, user_id: pt_session_log.user_id, pt_session_log_id: pt_session_log.id, exercise_id: Exercise.all.sample.id)
-  end
-end
-
-#------------------------------------------
-Rake::Task["db:seed:slit_logs"].invoke(user.id)
+Rake::Task["db:seed:exercise_logs"].invoke(user.id, 30)
+Rake::Task["db:seed:pain_logs"].invoke(user.id, 30)
+Rake::Task["db:seed:pt_session_logs"].invoke(user.id, 30)
+Rake::Task["db:seed:slit_logs"].invoke(user.id, 90)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ User.destroy_all
 #-------------------------------------------
 puts 'Seeding Users'
 existing_user = User.find_by(email: 'admin@email.com', admin: true)
-user = existing_user.present? ? existing_user : FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@email.com', admin: true)
+user = existing_user.present? ? existing_user : FactoryBot.create(:user, email: 'admin@email.com', admin: true)
 
 
 #-------------------------------------------

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ FactoryBot.create(:exercise, user_id: user.id, name: 'cross-body isometrics', de
 
 #------------------------------------------
 puts 'Seeding Body Parts'
-body_part_names = ['hip, right', 'hip, left', 'knee, right', 'knee, left']
+body_part_names = ['hip, right', 'hip, left', 'knee, right', 'knee, left', 'head']
 
 body_part_names.each do |body_part_name|
   FactoryBot.create(:body_part, user_id: user.id, name: body_part_name)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,7 @@ User.destroy_all
 #-------------------------------------------
 #            CREATE USER
 #-------------------------------------------
-puts 'Building Users'
+puts 'Seeding Users'
 existing_user = User.find_by(email: 'admin@email.com', admin: true)
 user = existing_user.present? ? existing_user : FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@email.com', admin: true)
 
@@ -25,14 +25,14 @@ user = existing_user.present? ? existing_user : FactoryBot.create(:user, first_n
 #-------------------------------------------
 #            BUILD BASE CLASSES
 #-------------------------------------------
-puts 'Building Exercises'
+puts 'Seeding Exercises'
 FactoryBot.create(:exercise, user_id: user.id, name: 'clam shells', description: 'lie on one side with legs bent at knees', default_per_side: true )
 FactoryBot.create(:exercise, user_id: user.id, name: 'wall slides', description: 'lie on side with body flat against wall. raise leg up, sliding heel againt wall.', default_per_side: true )
 FactoryBot.create(:exercise, user_id: user.id, name: 'bridges', description: 'lie on back with legs bent at knees. lift butt up.' )
 FactoryBot.create(:exercise, user_id: user.id, name: 'cross-body isometrics', description: 'lie on back with legs bent at knees. bring right knee towards chest but push back with left hand. hold and engage core. alternate sides.' )
 
 #------------------------------------------
-puts 'Building Body Parts'
+puts 'Seeding Body Parts'
 body_part_names = ['hip, right', 'hip, left', 'knee, right', 'knee, left']
 
 body_part_names.each do |body_part_name|
@@ -41,7 +41,7 @@ end
 
 
 #------------------------------------------
-puts 'Building Pains'
+puts 'Seeding Pains'
 pain_names = ['aching', 'burning', 'throbbing', 'stabbing', 'stiffness']
 
 pain_names.each do |pain_name|
@@ -52,8 +52,11 @@ end
 #-------------------------------------------
 #              BUILD LOGS
 #-------------------------------------------
-puts 'Building Logs'
+puts 'Seeding Logs...'
 Rake::Task["db:seed:exercise_logs"].invoke(user.id, 30)
 Rake::Task["db:seed:pain_logs"].invoke(user.id, 30)
 Rake::Task["db:seed:pt_session_logs"].invoke(user.id, 30)
 Rake::Task["db:seed:slit_logs"].invoke(user.id, 90)
+
+
+puts "Done."

--- a/lib/tasks/seed/exercise_logs.rake
+++ b/lib/tasks/seed/exercise_logs.rake
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :seed do
+    desc 'Create Exercise Logs'
+    task :exercise_logs, [:user_id, :quantity] => [:environment] do |_task, args|
+      puts 'Removing all exercise Logs'
+      ExerciseLog.destroy_all
+
+      user_id = if args[:user_id].present?
+        args[:user_id]
+      else
+        existing_user = User.find_by(email: 'admin@email.com', admin: true)
+        existing_user.present? ? existing_user.id : FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@email.com', admin: true).id
+      end
+
+      quantity = args[:quantity].presence || 30
+
+      puts 'Seeding Exercise Logs'
+      progress_notes = [
+        'generally feels more supported, but pain is still very present',
+        'feeling good this morning. hip cracked during exercise and that felt nice.',
+        'feels weaker than other side. Didn’t notice much of a difference after this session.',
+        'Went for a walk right afterwards. We did 1 little loop and i was not feeling much pain, so we did another small loop.',
+        'feels weaker than right also, hip is a little sore this morning in the joint. it doesn’t feel like workout sore.',
+        'still feels weaker than other side. weird. no muscle soreness from exercise.',
+        'feels weaker than other side also is a little sore this morning in the joint.'
+      ]
+
+      quantity.times do
+        FactoryBot.create(
+          :exercise_log,
+          user_id: user_id,
+          body_part_id: BodyPart.all.sample.id,
+          exercise_id: Exercise.all.sample.id,
+          occurred_at: Faker::Time.between(from: 3.month.ago, to: DateTime.current),
+          progress_note: progress_notes.sample
+        )
+      end
+    end
+  end
+end

--- a/lib/tasks/seed/exercise_logs.rake
+++ b/lib/tasks/seed/exercise_logs.rake
@@ -4,7 +4,6 @@ namespace :db do
   namespace :seed do
     desc 'Create Exercise Logs'
     task :exercise_logs, [:user_id, :quantity] => [:environment] do |_task, args|
-      puts 'Removing all exercise Logs'
       ExerciseLog.destroy_all
 
       user_id = if args[:user_id].present?

--- a/lib/tasks/seed/pain_logs.rake
+++ b/lib/tasks/seed/pain_logs.rake
@@ -4,7 +4,6 @@ namespace :db do
   namespace :seed do
     desc 'Create Pain Logs'
     task :pain_logs, [:user_id, :quantity] => [:environment] do |_task, args|
-      puts 'Removing all pain Logs'
       PainLog.destroy_all
 
       user_id = if args[:user_id].present?

--- a/lib/tasks/seed/pain_logs.rake
+++ b/lib/tasks/seed/pain_logs.rake
@@ -2,12 +2,11 @@
 
 namespace :db do
   namespace :seed do
-    desc 'Create SLIT Logs'
-    task :slit_logs, [:user_id, :quantity] => [:environment] do |_task, args|
-      puts 'Removing all SLIT Logs'
-      SlitLog.destroy_all
+    desc 'Create Pain Logs'
+    task :pain_logs, [:user_id, :quantity] => [:environment] do |_task, args|
+      puts 'Removing all pain Logs'
+      PainLog.destroy_all
 
-      puts 'Seeding SLIT Logs'
       user_id = if args[:user_id].present?
         args[:user_id]
       else
@@ -15,16 +14,16 @@ namespace :db do
         existing_user.present? ? existing_user.id : FactoryBot.create(:user, first_name: 'Admin', last_name: 'McAdmins', email: 'admin@email.com', admin: true).id
       end
 
-      quantity = args[:quantity].presence || 90
-      start_date = DateTime.current - quantity
+      quantity = args[:quantity].presence || 30
 
-      quantity.times do |i|
+      puts 'Seeding Pain Logs'
+      quantity.times do
         FactoryBot.create(
-          :slit_log,
+          :pain_log,
           user_id: user_id,
-          started_new_bottle:(i % 45 == 0),
-          dose_skipped: i != 0 && (i % 13 == 0),
-          occurred_at: (start_date + i + 1)
+          body_part_id: BodyPart.all.sample.id,
+          pain_id: Pain.all.sample.id,
+          occurred_at: Faker::Time.between(from: 3.month.ago, to: DateTime.current)
         )
       end
     end

--- a/lib/tasks/seed/pt_session_logs.rake
+++ b/lib/tasks/seed/pt_session_logs.rake
@@ -4,11 +4,9 @@ namespace :db do
   namespace :seed do
     desc 'Seed PT Session Logs'
     task :pt_session_logs, [:user_id, :quantity] => [:environment] do |_task, args|
-      puts 'Removing all PT Session Logs'
       PtSessionLog.destroy_all
 
       user_id = if args[:user_id].present?
-        binding.pry
         args[:user_id]
       else
         existing_user = User.find_by(email: 'admin@email.com', admin: true)

--- a/lib/tasks/seed/pt_session_logs.rake
+++ b/lib/tasks/seed/pt_session_logs.rake
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :seed do
+    desc 'Seed PT Session Logs'
+    task :pt_session_logs, [:user_id, :quantity] => [:environment] do |_task, args|
+      puts 'Removing all PT Session Logs'
+      PtSessionLog.destroy_all
+
+      user_id = if args[:user_id].present?
+        binding.pry
+        args[:user_id]
+      else
+        existing_user = User.find_by(email: 'admin@email.com', admin: true)
+        existing_user.present? ? existing_user.id : FactoryBot.create(:user, first_name: 'Seeded', last_name: 'Admin', email: 'admin@email.com', admin: true).id
+      end
+
+      quantity = args[:quantity].presence || 30
+
+      puts 'Seeding PT Session Logs'
+      quantity.times do
+        pt_session_log = FactoryBot.create(
+          :pt_session_log,
+          user_id: user_id,
+          body_part_id: BodyPart.all.sample.id,
+          occurred_at: Faker::Time.between(from: 3.month.ago, to: DateTime.current),
+          exercise_notes: exercise_note_opts.sample,
+          homework: homework_notes.sample
+        )
+
+        exercise_multiplier = (1..(Exercise.count)).to_a.sample
+        pt_session_log.homework_exercises << Exercise.all.sample(exercise_multiplier)
+
+        exercise_multiplier.times do
+          FactoryBot.create(
+            :exercise_log,
+            user_id: user_id,
+            pt_session_log_id: pt_session_log.id,
+            body_part_id: BodyPart.all.sample.id,
+            exercise_id: Exercise.all.sample.id,
+            occurred_at: Faker::Time.between(from: 3.month.ago, to: DateTime.current)
+          )
+        end
+      end
+
+    end # task
+  end #seed
+end # db
+
+def exercise_note_opts
+  [
+    'leveled up this time. used harder band. did one more set on most exercises',
+    'tried a new warmup this time. dr says flexibility is good, but need to do more. showed me 2 new stretches.',
+    'did strength testing for benchmarks. there is improvement since last week.',
+  ]
+end
+
+def homework_notes
+  [
+    'same as session',
+    'do regular exercises and incorporate in 1 or two extra sets or reps where you can',
+    'regular exercises plus add in an extra walk around the neighborhood',
+    'regular exercises plus add in an extra bike ride',
+    'try walking as fast as you can to see how far you can get before pain sets in'
+  ]
+end

--- a/lib/tasks/seed/slit_logs.rake
+++ b/lib/tasks/seed/slit_logs.rake
@@ -4,7 +4,6 @@ namespace :db do
   namespace :seed do
     desc 'Create SLIT Logs'
     task :slit_logs, [:user_id, :quantity] => [:environment] do |_task, args|
-      puts 'Removing all SLIT Logs'
       SlitLog.destroy_all
 
       puts 'Seeding SLIT Logs'


### PR DESCRIPTION
## Problems Solved
* Allows for running of segments of seeds file by running individual tasks like `rake db:seed:slit_logs`
* Can run all seeds with `rake db:seed` as normal
* Is mostly idempotent, but not quite. It does find-or-create for some items but destroys others
* Makes seeds file tidier by separating logging seeds into own task files

## Things Learned
* Full seed idempotency is tricky. Depending on whether you plan to run seeds on a clean db or an existing one means different things. Planning for both adds complexity.

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
