### PR TITLE
Comment out pagination for SLIT reports

### DIFF
--- a/app/controllers/slit_log_reports_controller.rb
+++ b/app/controllers/slit_log_reports_controller.rb
@@ -6,7 +6,7 @@ class SlitLogReportsController < ApplicationController
     end_date = search_params[:end_date].to_date.end_of_day
     logs = current_user.slit_logs.where(occurred_at: start_date..end_date)
                        .order(occurred_at: :asc)
-                       .paginate(page: params[:page], per_page: SlitLogReport::RECORD_LIMIT)
+                      #  .paginate(page: params[:page], per_page: SlitLogReport::RECORD_LIMIT)
 
     @logs = SlitLogDecorator.decorate_collection(logs)
   end

--- a/app/controllers/slit_log_reports_controller.rb
+++ b/app/controllers/slit_log_reports_controller.rb
@@ -6,7 +6,7 @@ class SlitLogReportsController < ApplicationController
     end_date = search_params[:end_date].to_date.end_of_day
     logs = current_user.slit_logs.where(occurred_at: start_date..end_date)
                        .order(occurred_at: :asc)
-                      #  .paginate(page: params[:page], per_page: SlitLogReport::RECORD_LIMIT)
+    #  .paginate(page: params[:page], per_page: SlitLogReport::RECORD_LIMIT)
 
     @logs = SlitLogDecorator.decorate_collection(logs)
   end

--- a/app/views/slit_log_reports/index.html.erb
+++ b/app/views/slit_log_reports/index.html.erb
@@ -31,4 +31,4 @@
   <% end %>
 </div>
 
-<%= will_paginate @logs, page_links: false, class: "pagination mt-3 mb-0" %>
+<%#= will_paginate @logs, page_links: false, class: "pagination mt-3 mb-0" %>


### PR DESCRIPTION
## Problems Solved
* pagination on the SLIT report for print makes the numbers reset when going to page 2. This is inaccurate and annoying.
* leaves pagination code in place in case i have immediate regrets


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I have written new specs for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
