### PR TITLE
Fix stats page

### DIFF
--- a/app/models/occurrence_calculator.rb
+++ b/app/models/occurrence_calculator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "ostruct"
 
 class OccurrenceCalculator
@@ -9,11 +10,15 @@ class OccurrenceCalculator
   end
 
   def avg_pain_level
+    return 0 if occurrences.empty?
+
     (pain_levels.sum / occurrences.length).to_i
   end
 
   def frequency
     occurrence_qty = occurrences.length
+    return "never" if occurrence_qty.zero?
+
     if occurrence_qty == 1
       "once"
     elsif occurrence_qty >= timeframe.qty
@@ -26,6 +31,14 @@ class OccurrenceCalculator
   end
 
   def timeframe
+    # Handle edge case where there are no occurrences or only one
+    if occurrences.empty? || first_datetime.nil? || last_datetime.nil?
+      data = OpenStruct.new
+      data.qty = 1.0
+      data.unit = "day"
+      return data
+    end
+
     seconds = last_datetime - first_datetime
     days_between_first_and_last = (seconds / 60 / 60 / 24)
     data = OpenStruct.new

--- a/spec/models/occurrence_calculator_spec.rb
+++ b/spec/models/occurrence_calculator_spec.rb
@@ -27,9 +27,25 @@ RSpec.describe OccurrenceCalculator, type: :model do
 
       expect(calculator.avg_pain_level).to eq(2)
     end
+
+    context "with no occurrences" do
+      let(:occurrences) { [] }
+
+      it "returns 0" do
+        expect(calculator.avg_pain_level).to eq(0)
+      end
+    end
   end
 
   describe "frequency" do
+    context "when there are no occurrences" do
+      let(:occurrences) { [] }
+
+      it 'returns "never"' do
+        expect(calculator.frequency).to eq("never")
+      end
+    end
+
     context "when it only happened once" do
       let(:pain_log1) { create(:pain_log, body_part: body_part, pain: pain, occurred_at: today - 1.month) }
       let(:occurrences) { [pain_log1] }
@@ -69,6 +85,15 @@ RSpec.describe OccurrenceCalculator, type: :model do
     let(:pain_log5) { create(:pain_log, body_part: body_part, pain: pain, occurred_at: today - 2.weeks) }
     let(:pain_log6) { create(:pain_log, body_part: body_part, pain: pain, occurred_at: today - 2.years) }
     let(:occurrences) { [pain_log1, pain_log2] }
+
+    context "with no occurrences" do
+      let(:occurrences) { [] }
+
+      it "returns a default timeframe" do
+        expect(calculator.timeframe.qty).to eq(1.0)
+        expect(calculator.timeframe.unit).to eq("day")
+      end
+    end
 
     it "returns the timeframe between the first and last occurrences" do
       expect(calculator.timeframe.qty).to eq(2.0)


### PR DESCRIPTION
## Related Issues & PRs
https://anne-richardson.sentry.io/issues/7066912835/?referrer=alert_email&alert_type=email&alert_timestamp=1764167858331&alert_rule_id=14067647&notification_uuid=329ff932-3104-4588-9daf-f93b3cf1b5cd&environment=production

## Problems Solved
There was a problem in production (not locally) with OpenStruct not being recognized. This is most likely due to a loading time error. 

However, there is another bug where empty data was not being handled while calculating occurrences of pains. This PR handles both problems.

## Screenshots
<img width="882" height="304" alt="Screenshot 2025-11-26 at 10 38 11 AM" src="https://github.com/user-attachments/assets/4cbf5d6f-64a4-4f52-846d-9f69ef4fac54" />
<img width="667" height="686" alt="Screenshot 2025-11-26 at 10 38 27 AM" src="https://github.com/user-attachments/assets/21201a71-3c63-47a1-a737-632de57f9a53" />


## Due Diligence Checks
- [ ] ~If this work contains migrations, I have updated factories and seeds accordingly~
- [x] I can confirm there is spec coverage for this work
- [x] I have browser tested this work
- [x] I have deployed the feature branch to production and browser tested it successfully
