### PR TITLE
Clean bootsnap cache and bundle in CI

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       # Add or replace dependency steps here
+      - name: Clean bootsnap cache and vendor bundle
+        run: |
+          rm -rf vendor/bundle tmp/cache
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "sprockets-rails"
 gem "stimulus-rails"
 gem "turbo-rails"
 
-gem "bootsnap", ">= 1.7.7", require: false
+gem "bootsnap", ">= 1.21.1", require: false
 gem "chartkick", ">= 3.2.0" # chart rendering for ruby data
 gem "devise" # user authentication
 gem "groupdate" # grouping by dates. goes with chartkick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.10-java)
       racc (~> 1.4)
+    nokogiri (1.18.10-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -314,6 +316,8 @@ GEM
       racc
     path_expander (1.1.3)
     pg (1.6.3)
+    pg (1.6.3-x64-mingw-ucrt)
+    pg (1.6.3-x86_64-darwin)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -610,7 +614,7 @@ DEPENDENCIES
   awesome_print
   better_errors
   binding_of_caller
-  bootsnap (>= 1.7.7)
+  bootsnap (>= 1.21.1)
   bullet
   byebug
   capybara


### PR DESCRIPTION
## Related Issues & PRs
https://github.com/lortza/therapy_tracker/actions/runs/21177324833/job/60909636921?pr=1072


## Problems Solved
* This PR is trying to resolve the problem where the test CI job is failing. The hypothesis is that the bundler cache needs to be cleared in case of ruby version mis-match


## Due Diligence Checks
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
