### PR TITLE
Add delete link to quick log edit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,20 @@
 ## Related Issues & PRs
-
 Closes #X
 
 ## Problems Solved
-
 -
 
 ## Screenshots
-
 [screenshots here]
 
 ## Things Learned
-
 -
 
 ## Due Diligence Checks
 
 - [ ] If this work contains migrations, I have updated factories and seeds accordingly
 - [ ] I can confirm there is spec coverage for this work
-- [ ] I have browser tested this work
+- [ ] I have tested this work in the browser
+- [ ] I have tested this work in the console
+- [ ] I have reviewed this PR
 - [ ] I have deployed the feature branch to production and browser tested it successfully

--- a/app/views/pain_log_quick_form_values/edit.html.erb
+++ b/app/views/pain_log_quick_form_values/edit.html.erb
@@ -1,3 +1,5 @@
 <h1>Editing default values for: <%= @pain_log_quick_form_value.name %></h1>
 <p>Any changes you make to this data will become the new default values for your quick-logging shortcut. If you want to edit a specific pain experience, go to <%= link_to 'pain logs', pain_logs_path %> and edit the appropriate pain log.</p>
 <%= render 'form', pain_log_quick_form_value: @pain_log_quick_form_value %>
+
+<%= render partial: 'shared/delete_footer', locals: { object: @pain_log_quick_form_value, delete_path: @pain_log_quick_form_value, message: 'Are you sure you want to delete this quick log template?' } %>


### PR DESCRIPTION
## Related Issues & PRs

Closes #1162

## Problems Solved
- Allows a user to clean up quick logging templates they're no longer using
- I also just updated the PR template because I didn't feel like doing a separate PR and this is a super low stakes release

## Screenshots
<img width="1139" height="789" alt="Screenshot 2026-04-22 at 4 41 37 PM" src="https://github.com/user-attachments/assets/9a61d0e2-ecac-4ca5-8a8d-00c14747b92e" />


## Things Learned
- I already had everything else in place. yeehaw!

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have browser tested this work
- [ ] I have deployed the feature branch to production and browser tested it successfully
