### PR TITLE
Add decorator for survey response in log stream

### DIFF
--- a/app/assets/stylesheets/logs.css
+++ b/app/assets/stylesheets/logs.css
@@ -105,6 +105,14 @@
   color: var(--slit-color);
 }
 
+.log-type-survey .log-icon-color {
+  color: var(--survey-color);
+}
+
+.log-type-survey .card-title {
+  color: var(--survey-color);
+}
+
 .color-exercise {
   color: var(--exercise-color);
 }
@@ -119,6 +127,10 @@
 
 .color-slit {
   color: var(--slit-color);
+}
+
+.color-survey {
+  color: var(--survey-color);
 }
 
 .background-color-exercise {
@@ -137,6 +149,10 @@
   background-color: var(--slit-color);
 }
 
+.background-color-survey {
+  background-color: var(--survey-color);
+}
+
 .border-color-exercise {
   border-color: var(--exercise-color);
 }
@@ -151,4 +167,8 @@
 
 .border-color-slit {
   border-color: var(--slit-color);
+}
+
+.border-color-survey {
+  border-color: var(--survey-color);
 }

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -21,6 +21,14 @@
   --exercise-color: #48aa6c;
   --therapy-color: #0994a1;
   --slit-color: #8228d5;
-
+  --survey-color: #EF798A;
+  
   --bootstrap-card-border-radius: 10px;
 }
+
+/* Other colors that match the scheme but aren't in-use yet */
+/* --juicy-orange: #DE6B48; */
+/* --medium-mulch: #696047; */
+/* --juicy-magenta: #D81159; */
+/* --burnt-umber: #A72608; */
+/* --dusty-mustard: #A98743; */

--- a/app/decorators/survey/response_decorator.rb
+++ b/app/decorators/survey/response_decorator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Survey::ResponseDecorator < ApplicationDecorator
+  delegate_all
+
+  def display_name
+    survey.name
+  end
+
+  def icon_name
+    "psychology_alt"
+  end
+
+  def css_name
+    "survey"
+  end
+
+  def score_name
+    score_range_step&.name&.titleize
+  end
+
+  def score_description
+    score_range_step&.description
+  end
+
+  def difference_from_previous_response
+    return nil unless previous_response
+
+    points = total_score - previous_response.total_score
+    case points
+    when 0
+      "No change from previous response"
+    else
+      "#{"+" if points > 0}#{points} from previous response"
+    end
+
+    if points == 0
+      "No change from previous response"
+    elsif points > 0
+      "+#{points} from previous response ☹️"
+    else
+      "#{points} from previous response 😀"
+    end
+  end
+end

--- a/app/models/concerns/log.rb
+++ b/app/models/concerns/log.rb
@@ -3,14 +3,13 @@
 module Log
   # class methods for querying logs
 
-  # TODO: decorate survey responses when displaying them in the log stream
   def self.all(user)
     logs = [
       user.pt_session_logs.decorate.to_a,
       user.pain_logs.decorate.to_a,
       user.exercise_logs.at_home.decorate.to_a,
-      user.slit_logs.decorate.to_a
-      # user.survey_responses.includes(:survey).decorate.to_a
+      user.slit_logs.decorate.to_a,
+      user.survey_responses.includes(:survey).decorate.to_a
     ]
 
     logs.flatten.sort_by { |a| a[:occurred_at] }.reverse!

--- a/app/models/survey/response.rb
+++ b/app/models/survey/response.rb
@@ -43,4 +43,12 @@ class Survey::Response < ApplicationRecord
   def calculate_total_score
     answers.sum(&:answer_option_value)
   end
+
+  def score_range_step
+    @score_range_step ||= survey.score_range_steps.where("calculated_range_min_points <= ? AND calculated_range_max_points >= ?", total_score, total_score).first
+  end
+
+  def previous_response
+    @previous_response ||= survey.responses.where(user_id: user_id, occurred_at: ...occurred_at).order(:occurred_at).last
+  end
 end

--- a/app/views/survey/responses/_response.html.erb
+++ b/app/views/survey/responses/_response.html.erb
@@ -1,0 +1,17 @@
+<% @log_content = capture do %>
+  <h5 class='card-title color-response'><%= response.survey.name.titleize %> Taken: <%= format_datetime(response.occurred_at) %></h5>
+  <p class="card-text">Score: <%= response.total_score %>/<%= response.survey.max_score %> <%= response.score_name %> <% if response.score_description %>: <%= response.score_description %><% end %><br>
+    <%= response.difference_from_previous_response %><br>
+    <small class="text-muted"><%= response.notes %></small>
+  </p>
+<% end %>
+
+<!-- TODO: Add link to view completed response -->
+<%= render partial: '/logs/log_component',
+  locals: {
+    log: response,
+    log_content: @log_content,
+    edit_path: "#",
+    error_condition: false
+  }
+%>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,5 +59,6 @@ Rake::Task["db:seed:slit_logs"].invoke(user.id, 90)
 #-------------------------------------------
 # Rake::Task["db:seed:surveys"].invoke
 Rake::Task["db:seed:surveys"].invoke(user.id)
+Rake::Task["db:seed:survey_responses"].invoke(user.id)
 
 puts "Finished Seeding."

--- a/lib/tasks/seed/surveys.rake
+++ b/lib/tasks/seed/surveys.rake
@@ -94,5 +94,41 @@ namespace :db do
       survey.calculate_score_range_steps_points
       puts "Finished seeding surveys."
     end
+
+    task :survey_responses, [:user_id, :survey_id] => [:environment] do |_task, args|
+      puts "Seeding Survey Responses..."
+      Survey::Response.destroy_all
+
+      user = if args[:user_id].present?
+        args[:user_id]
+        User.find(args[:user_id])
+      else
+        existing_user = User.find_by(email: "admin@email.com", admin: true)
+        existing_user.present? ? existing_user : FactoryBot.create(:user, first_name: "Admin", last_name: "McAdmins", email: "admin@email.com", admin: true)
+      end
+
+      survey = if args[:survey_id].present?
+        args[:survey_id]
+        Survey.find(args[:survey_id])
+      else
+        Survey.first
+      end
+
+      3.times do |i|
+        response = survey.responses.create!(
+          user_id: user.id,
+          occurred_at: (i * 5).days.ago
+        )
+
+        survey.questions.each do |question|
+          response.answers.create!(
+            survey_question_id: question.id,
+            survey_answer_option_id: survey.answer_options.sample.id
+          )
+        end
+      end
+
+      puts "Finished seeding survey responses."
+    end
   end
 end

--- a/spec/decorators/survey/response_decorator_spec.rb
+++ b/spec/decorators/survey/response_decorator_spec.rb
@@ -1,0 +1,76 @@
+# spec/decorators/todo_decorator_spec.rb
+require "rails_helper"
+
+describe Survey::ResponseDecorator do
+  let(:survey_response) { Survey::Response.new.extend(Draper::Decoratable) }
+  let(:decorator) { Survey::ResponseDecorator.new(survey_response) }
+
+  describe "#display_name" do
+    it "returns the name of the associated survey" do
+      survey = create(:survey, name: "My Survey")
+      survey_response.survey = survey
+
+      expect(decorator.display_name).to eq("My Survey")
+    end
+  end
+
+  describe "score_name" do
+    it "returns the titleized name of the score range step" do
+      allow(survey_response).to receive(:score_range_step).and_return(double(name: "mild symptoms", description: nil))
+
+      expect(decorator.score_name).to eq("Mild Symptoms")
+    end
+
+    it "returns nil when there is no score range step" do
+      allow(survey_response).to receive(:score_range_step).and_return(nil)
+
+      expect(decorator.score_name).to be_nil
+    end
+  end
+
+  describe "score_description" do
+    it "returns the description of the score range step" do
+      allow(survey_response).to receive(:score_range_step).and_return(double(name: "Mild", description: "Symptoms are mild"))
+
+      expect(decorator.score_description).to eq("Symptoms are mild")
+    end
+
+    it "returns nil when there is no score range step" do
+      allow(survey_response).to receive(:score_range_step).and_return(nil)
+
+      expect(decorator.score_description).to be_nil
+    end
+  end
+
+  describe "difference_from_previous_response" do
+    it "returns nil when there is no previous response" do
+      allow(survey_response).to receive(:previous_response).and_return(nil)
+
+      expect(decorator.difference_from_previous_response).to be_nil
+    end
+
+    it "returns a no-change message when score is the same as the previous response" do
+      previous = double(total_score: 10)
+      allow(survey_response).to receive(:previous_response).and_return(previous)
+      allow(survey_response).to receive(:total_score).and_return(10)
+
+      expect(decorator.difference_from_previous_response).to eq("No change from previous response")
+    end
+
+    it "returns a message with a frowning emoji when score is higher than the previous response" do
+      previous = double(total_score: 5)
+      allow(survey_response).to receive(:previous_response).and_return(previous)
+      allow(survey_response).to receive(:total_score).and_return(8)
+
+      expect(decorator.difference_from_previous_response).to eq("+3 from previous response ☹️")
+    end
+
+    it "returns a message with a happy emoji when score is lower than the previous response" do
+      previous = double(total_score: 10)
+      allow(survey_response).to receive(:previous_response).and_return(previous)
+      allow(survey_response).to receive(:total_score).and_return(7)
+
+      expect(decorator.difference_from_previous_response).to eq("-3 from previous response 😀")
+    end
+  end
+end

--- a/spec/models/survey/response_spec.rb
+++ b/spec/models/survey/response_spec.rb
@@ -63,4 +63,57 @@ RSpec.describe Survey::Response, type: :model do
       expect(survey_response.reload.calculate_total_score).to eq(5) # 2 + 3
     end
   end
+
+  describe "score_range_step" do
+    let(:survey) { create(:survey) }
+    let(:survey_response) { create(:survey_response, survey: survey) }
+
+    it "returns the score range step whose range includes the total score" do
+      matching_step = create(:survey_score_range_step, survey: survey, calculated_range_min_points: 0, calculated_range_max_points: 10)
+      create(:survey_score_range_step, survey: survey, calculated_range_min_points: 11, calculated_range_max_points: 20)
+
+      allow(survey_response).to receive(:total_score).and_return(5)
+
+      expect(survey_response.score_range_step).to eq(matching_step)
+    end
+
+    it "returns nil when no score range step covers the total score" do
+      create(:survey_score_range_step, survey: survey, calculated_range_min_points: 11, calculated_range_max_points: 20)
+
+      allow(survey_response).to receive(:total_score).and_return(5)
+
+      expect(survey_response.score_range_step).to be_nil
+    end
+  end
+
+  describe "previous_response" do
+    let(:survey) { create(:survey) }
+    let(:user) { create(:user) }
+
+    it "returns the most recent response for the same user and survey before the current response" do
+      older = create(:survey_response, survey: survey, user: user, occurred_at: 3.days.ago)
+      newer = create(:survey_response, survey: survey, user: user, occurred_at: 2.days.ago)
+      current = create(:survey_response, survey: survey, user: user, occurred_at: 1.day.ago)
+
+      expect(current.previous_response).to eq(newer)
+      expect(newer.previous_response).to eq(older)
+      expect(older.previous_response).to be_nil
+    end
+
+    it "does not return responses from a different user" do
+      other_user = create(:user)
+      create(:survey_response, survey: survey, user: other_user, occurred_at: 2.days.ago)
+      current = create(:survey_response, survey: survey, user: user, occurred_at: 1.day.ago)
+
+      expect(current.previous_response).to be_nil
+    end
+
+    it "does not return responses from a different survey" do
+      other_survey = create(:survey)
+      create(:survey_response, survey: other_survey, user: user, occurred_at: 2.days.ago)
+      current = create(:survey_response, survey: survey, user: user, occurred_at: 1.day.ago)
+
+      expect(current.previous_response).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Related Issues & PRs
Closes #1151 

## Problems Solved
- The survey feature is not rolled out yet, so no survey responses will show up in the log stream.
- When a user is able to take a survey, this will be ready for them to see the response in their log stream.
- Adds visual summary of survey to the user's log stream
- Shows difference between this response and the previous one (if there is a previous one)
- Shows the score and the interpretation of the score (ex 15/30 is Moderate)
- Shows description of interpretation if there is one
- Shows notes from the response if there are user-provided notes

## Screenshots
<img width="1257" height="788" alt="Screenshot 2026-04-23 at 10 08 12 AM" src="https://github.com/user-attachments/assets/9bac5a48-3d7e-455e-8025-e5e320bb119f" />


## Things Learned
- Decorators have some flexibility in how they handle namespacing
- It was fun to actually put some real decorator methods in a decorator and keep them out of the model!

## Due Diligence Checks

- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
