### PR TITLE
Add Admin Survey Index and Show pages

### DIFF
--- a/app/controllers/admin/surveys_controller.rb
+++ b/app/controllers/admin/surveys_controller.rb
@@ -1,0 +1,17 @@
+class Admin::SurveysController < AdminController
+  # before_action :set_survey, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @surveys = Survey.all
+  end
+
+  private
+
+  def set_survey
+    @survey = Survey.find(params[:id])
+  end
+
+  def survey_params
+    params.require(:survey).permit(:name, :description, :published, :available_to_public)
+  end
+end

--- a/app/controllers/admin/surveys_controller.rb
+++ b/app/controllers/admin/surveys_controller.rb
@@ -1,8 +1,11 @@
 class Admin::SurveysController < AdminController
-  # before_action :set_survey, only: [:show, :edit, :update, :destroy]
+  before_action :set_survey, only: [:show]
 
   def index
     @surveys = Survey.all
+  end
+
+  def show
   end
 
   private

--- a/app/views/admin/surveys/index.html.erb
+++ b/app/views/admin/surveys/index.html.erb
@@ -1,0 +1,31 @@
+<% content_for(:title, "Manage Surveys") %>
+
+<%= link_to 'New Survey', new_admin_survey_path, class: button_class('primary pull-right') %>
+
+<h1>Manage Surveys</h1>
+
+<div class="container w-100 overflow-x-scroll">
+  <div class="row fw-bolder border-bottom border-top mb-0 text-bg-light">
+    <div class="col-2 py-1 px-2">Name</div>
+    <div class="col-4 py-1 px-2">Description</div>
+    <div class="col-1 py-1 px-2">Status</div>
+    <div class="col-2 py-1 px-2">Responses</div>
+    <div class="col-3 py-1 px-2">Actions</div>
+  </div>
+  
+  <% @surveys.each do |survey| %>
+    <div class="row border-bottom mb-0">
+      <div class="col-2 py-1 px-2"><%= link_to survey.name, admin_survey_path(survey) %></div>
+      <div class="col-4 py-1 px-2"><%= survey.description %></div>
+      <div class="col-1 py-1 px-2"><%= survey.published? ? "Published" : "Draft" %></div>
+      <div class="col-2 py-1 px-2"><%= survey.responses.count %></div>
+      <div class="col-3 py-1 px-2">
+        <!-- TODO: use policies to display available action buttons -->
+        <%= link_to "Edit", edit_admin_survey_path(survey), class: "btn btn-sm btn-primary" %>
+        <%= link_to "Publish", '#', class: "btn btn-sm btn-primary" %>
+        <%= link_to "Archive", '#', class: "btn btn-sm btn-primary" %>
+        <%= link_to "Delete", admin_survey_path(survey), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-danger" unless survey.published? %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/surveys/index.html.erb
+++ b/app/views/admin/surveys/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, "Manage Surveys") %>
 
-<%= link_to 'New Survey', new_admin_survey_path, class: button_class('primary pull-right') %>
+<%#= link_to 'New Survey', new_admin_survey_path, class: button_class('primary pull-right') %>
 
 <h1>Manage Surveys</h1>
 
@@ -18,13 +18,13 @@
       <div class="col-2 py-1 px-2"><%= link_to survey.name, admin_survey_path(survey) %></div>
       <div class="col-4 py-1 px-2"><%= survey.description %></div>
       <div class="col-1 py-1 px-2"><%= survey.published? ? "Published" : "Draft" %></div>
-      <div class="col-2 py-1 px-2"><%= survey.responses.count %></div>
+      <div class="col-2 py-1 px-2"><%= survey.responses.size %></div>
       <div class="col-3 py-1 px-2">
         <!-- TODO: use policies to display available action buttons -->
-        <%= link_to "Edit", edit_admin_survey_path(survey), class: "btn btn-sm btn-primary" %>
+        <%#= link_to "Edit", edit_admin_survey_path(survey), class: "btn btn-sm btn-primary" %>
         <%= link_to "Publish", '#', class: "btn btn-sm btn-primary" %>
         <%= link_to "Archive", '#', class: "btn btn-sm btn-primary" %>
-        <%= link_to "Delete", admin_survey_path(survey), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-danger" unless survey.published? %>
+        <%#= link_to "Delete", admin_survey_path(survey), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-danger" unless survey.published? %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -1,0 +1,38 @@
+<% content_for(:title, @survey.name) %>
+
+<h1><%= @survey.name.titleize %> <span class="fs-6 text"><%= @survey.published? ? "(Published)" : "(Draft)" %></span></h1>
+<p><%= @survey.description %></p>    
+<div class="row">
+  <div class="col-7">
+    <h2 class="fs-4 text">Questions</h2>
+    <% @survey.categories.each do |category| %>
+      <h3 class="fs-5 text"><%= category.name %></h3>
+      <ul>
+        <% category.questions.each do |question| %>
+          <li><%= question.position %>: <%= question.text %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+
+  <div class="col-5">
+    <h2 class="fs-4 text">Answer Options</h2>
+    <ul>
+      <% @survey.answer_options.each do |option| %>
+        <li><%= option.value %>: <%= option.name %></li>
+      <% end %>
+    </ul>
+  </div>
+</div>
+
+
+
+
+
+<h2 class="fs-4 text">Score Interpretation</h2>
+<ul>
+  <% @survey.score_range_steps.each do |step| %>
+    <li><strong><%= step.calculated_range_min_points %>-<%= step.calculated_range_max_points %>: <%= step.name %></strong> - <%= step.description %></li>
+  <% end %>
+</ul>
+

--- a/app/views/shared/_admin_nav.html.erb
+++ b/app/views/shared/_admin_nav.html.erb
@@ -5,6 +5,7 @@
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
       <%= link_to 'Users', admin_users_path, class: 'dropdown-item' %>
+      <%= link_to 'Surveys', admin_surveys_path, class: 'dropdown-item' %>
     </div>
   </li>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,8 @@ Rails.application.routes.draw do
   root to: "logs#index"
 
   namespace :admin do
-    resources :users, only: [:index, :show]
+    resources :users, only: [:index, :show]  # existing
+    resources :surveys
   end
 
   resources :users, only: [:update]
@@ -42,4 +43,10 @@ Rails.application.routes.draw do
   post "/quick_log_create", to: "slit_logs#quick_log_create"
 
   resources :slit_log_reports, only: [:index, :new]
+
+  # NEW WIP ROUTES FOR SURVEYS
+  # resources :survey_enrollments, only: [:create, :destroy]
+  # resources :surveys, only: [:index, :show] do
+  #   resources :survey_responses, only: [:new, :create, :index, :show]
+  # end
 end

--- a/lib/tasks/seed/surveys.rake
+++ b/lib/tasks/seed/surveys.rake
@@ -33,47 +33,47 @@ namespace :db do
       # Category & Questions for Thoughts
       thoughts_category = survey.categories.create!(
         name: "Thoughts and Feelings",
-        position: 0
+        position: 1
       )
       thoughts_category.questions.create!(
         text: "I feel sad or down in the dumps.",
-        position: 0
+        position: 1
       )
       thoughts_category.questions.create!(
         text: "I have lost interest in my usual activities.",
-        position: 1
+        position: 2
       )
 
       # Category & Questions for Activities and Personal Relationships
       activities_category = survey.categories.create!(
         name: "Activities and Personal Relationships",
-        position: 1
+        position: 2
       )
 
       activities_category.questions.create!(
         text: "Loss of motivation or initiative.",
-        position: 0
+        position: 1
       )
 
       activities_category.questions.create!(
         text: "Loss of interest in family or friends",
-        position: 1
+        position: 2
       )
 
       # Category & Questions for Physical Symptoms
       physical_category = survey.categories.create!(
         name: "Physical Symptoms",
-        position: 2
+        position: 3
       )
 
       physical_category.questions.create!(
         text: "I have trouble sleeping at night.",
-        position: 0
+        position: 1
       )
 
       physical_category.questions.create!(
         text: "Worrying about health",
-        position: 1
+        position: 2
       )
 
       # Answer Options for all questions
@@ -84,12 +84,12 @@ namespace :db do
       survey.answer_options.create!(value: 4, name: "Extremely")
 
       # Score Ranges for the survey
-      survey.score_range_steps.create!(name: "No Depression", position: 1)
-      survey.score_range_steps.create!(name: "Normal but unhappy", position: 2)
-      survey.score_range_steps.create!(name: "Mild Depression", position: 3)
-      survey.score_range_steps.create!(name: "Moderate Depression", position: 4)
-      survey.score_range_steps.create!(name: "Severe Depression", position: 5)
-      survey.score_range_steps.create!(name: "Extreme Depression", position: 6)
+      survey.score_range_steps.create!(name: "No Depression", position: 1, description: "Your responses indicate that you are not currently experiencing symptoms of depression.")
+      survey.score_range_steps.create!(name: "Normal but unhappy", position: 2, description: "Your responses indicate that you are experiencing some negative feelings but not to a significant extent.")
+      survey.score_range_steps.create!(name: "Mild Depression", position: 3, description: "Your responses indicate that you are experiencing some symptoms of depression.")
+      survey.score_range_steps.create!(name: "Moderate Depression", position: 4, description: "Your responses indicate that you are experiencing moderate symptoms of depression.")
+      survey.score_range_steps.create!(name: "Severe Depression", position: 5, description: "Your responses indicate that you are experiencing severe symptoms of depression.")
+      survey.score_range_steps.create!(name: "Extreme Depression", position: 6, description: "Your responses indicate that you are experiencing extreme symptoms of depression.")
 
       survey.calculate_score_range_steps_points
       puts "Finished seeding surveys."

--- a/spec/requests/admin/surveys_spec.rb
+++ b/spec/requests/admin/surveys_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe "Admin::Surveys", type: :request do
       expect(response).to redirect_to new_user_session_path
     end
 
-    # it "redirects show to sign in" do
-    #   get admin_survey_path(survey)
-    #   expect(response).to redirect_to new_user_session_path
-    # end
+    it "redirects show to sign in" do
+      get admin_survey_path(survey)
+      expect(response).to redirect_to new_user_session_path
+    end
 
     # it "redirects new to sign in" do
     #   get new_admin_survey_path
@@ -53,10 +53,10 @@ RSpec.describe "Admin::Surveys", type: :request do
       expect(response).to redirect_to root_path
     end
 
-    # it "redirects show to root" do
-    #   get admin_survey_path(survey)
-    #   expect(response).to redirect_to root_path
-    # end
+    it "redirects show to root" do
+      get admin_survey_path(survey)
+      expect(response).to redirect_to root_path
+    end
 
     # it "redirects new to root" do
     #   get new_admin_survey_path
@@ -75,13 +75,13 @@ RSpec.describe "Admin::Surveys", type: :request do
       end
     end
 
-    # describe "GET /admin/surveys/:id" do
-    #   it "renders successfully" do
-    #     get admin_survey_path(survey)
-    #     expect(response).to be_successful
-    #     expect(response).to render_template(:show)
-    #   end
-    # end
+    describe "GET /admin/surveys/:id" do
+      it "renders successfully" do
+        get admin_survey_path(survey)
+        expect(response).to be_successful
+        expect(response).to render_template(:show)
+      end
+    end
 
     # describe "GET /admin/surveys/new" do
     #   it "renders successfully" do

--- a/spec/requests/admin/surveys_spec.rb
+++ b/spec/requests/admin/surveys_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Surveys", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:survey) { create(:survey) }
+
+  describe "unauthenticated access" do
+    it "redirects index to sign in" do
+      get admin_surveys_path
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    # it "redirects show to sign in" do
+    #   get admin_survey_path(survey)
+    #   expect(response).to redirect_to new_user_session_path
+    # end
+
+    # it "redirects new to sign in" do
+    #   get new_admin_survey_path
+    #   expect(response).to redirect_to new_user_session_path
+    # end
+
+    # it "redirects create to sign in" do
+    #   post admin_surveys_path, params: {survey: {name: "New Survey"}}
+    #   expect(response).to redirect_to new_user_session_path
+    # end
+
+    # it "redirects edit to sign in" do
+    #   get edit_admin_survey_path(survey)
+    #   expect(response).to redirect_to new_user_session_path
+    # end
+
+    # it "redirects update to sign in" do
+    #   patch admin_survey_path(survey), params: {survey: {name: "Updated"}}
+    #   expect(response).to redirect_to new_user_session_path
+    # end
+
+    # it "redirects destroy to sign in" do
+    #   delete admin_survey_path(survey)
+    #   expect(response).to redirect_to new_user_session_path
+    # end
+  end
+
+  describe "non-admin access" do
+    let(:non_admin) { create(:user, admin: false) }
+
+    before { sign_in(non_admin) }
+
+    it "redirects index to root" do
+      get admin_surveys_path
+      expect(response).to redirect_to root_path
+    end
+
+    # it "redirects show to root" do
+    #   get admin_survey_path(survey)
+    #   expect(response).to redirect_to root_path
+    # end
+
+    # it "redirects new to root" do
+    #   get new_admin_survey_path
+    #   expect(response).to redirect_to root_path
+    # end
+  end
+
+  describe "admin access" do
+    before { sign_in(admin) }
+
+    describe "GET /admin/surveys" do
+      it "renders successfully" do
+        get admin_surveys_path
+        expect(response).to be_successful
+        expect(response).to render_template(:index)
+      end
+    end
+
+    # describe "GET /admin/surveys/:id" do
+    #   it "renders successfully" do
+    #     get admin_survey_path(survey)
+    #     expect(response).to be_successful
+    #     expect(response).to render_template(:show)
+    #   end
+    # end
+
+    # describe "GET /admin/surveys/new" do
+    #   it "renders successfully" do
+    #     get new_admin_survey_path
+    #     expect(response).to be_successful
+    #     expect(response).to render_template(:new)
+    #   end
+    # end
+
+    # describe "POST /admin/surveys" do
+    #   context "with valid params" do
+    #     it "creates the survey and redirects to show" do
+    #       expect {
+    #         post admin_surveys_path, params: {survey: {name: "New Survey", description: "A description"}}
+    #       }.to change(Survey, :count).by(1)
+
+    #       expect(response).to redirect_to admin_survey_path(Survey.last)
+    #     end
+    #   end
+
+    #   context "with invalid params" do
+    #     it "does not create the survey and re-renders new" do
+    #       expect {
+    #         post admin_surveys_path, params: {survey: {name: ""}}
+    #       }.not_to change(Survey, :count)
+
+    #       expect(response).to render_template(:new)
+    #     end
+    #   end
+    # end
+
+    # describe "GET /admin/surveys/:id/edit" do
+    #   context "when the survey is not published" do
+    #     it "renders successfully" do
+    #       get edit_admin_survey_path(survey)
+    #       expect(response).to be_successful
+    #       expect(response).to render_template(:edit)
+    #     end
+    #   end
+
+    #   context "when the survey is published" do
+    #     let(:survey) { create(:survey, published: true) }
+
+    #     it "redirects to show with an alert" do
+    #       get edit_admin_survey_path(survey)
+    #       expect(response).to redirect_to admin_survey_path(survey)
+    #       expect(flash[:alert]).to be_present
+    #     end
+    #   end
+    # end
+
+    # describe "PATCH /admin/surveys/:id" do
+    #   context "with valid params" do
+    #     it "updates the survey and redirects to show" do
+    #       patch admin_survey_path(survey), params: {survey: {name: "Updated Name"}}
+
+    #       expect(survey.reload.name).to eq("Updated Name")
+    #       expect(response).to redirect_to admin_survey_path(survey)
+    #     end
+    #   end
+
+    #   context "with invalid params" do
+    #     it "does not update the survey and re-renders edit" do
+    #       original_name = survey.name
+    #       patch admin_survey_path(survey), params: {survey: {name: ""}}
+
+    #       expect(survey.reload.name).to eq(original_name)
+    #       expect(response).to render_template(:edit)
+    #     end
+    #   end
+    # end
+
+    # describe "DELETE /admin/surveys/:id" do
+    #   it "destroys the survey and redirects to index" do
+    #     survey_to_delete = create(:survey)
+
+    #     expect {
+    #       delete admin_survey_path(survey_to_delete)
+    #     }.to change(Survey, :count).by(-1)
+
+    #     expect(response).to redirect_to admin_surveys_path
+    #   end
+    # end
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
* #1152 
* #1153 

## This PR Does
- Adds an admin survey show page
- Adds an admin survey index page to show all surveys
- Links from the index page to the show page
- Adds a link to the surveys index from the admin nav menu
- Add the necessary routes and controller actions to support those pages
- Adds specs for those routes and commented out specs for the upcoming routes

## This PR Does not
- Include any editing or link to editing of any facets of surveys

## Screenshots
The nav bar change:
<img width="532" height="168" alt="Screenshot 2026-04-24 at 11 16 31 AM" src="https://github.com/user-attachments/assets/8a0abfa5-68a0-435b-af5f-f547b808c8bd" />

The index page
<img width="1270" height="354" alt="Screenshot 2026-04-24 at 11 16 38 AM" src="https://github.com/user-attachments/assets/54aba3c3-0351-416e-87ab-c8cfd9bb5fbc" />


The show page
<img width="1238" height="775" alt="Screenshot 2026-04-24 at 11 16 11 AM" src="https://github.com/user-attachments/assets/d8e12c92-7c69-4f2f-b942-86cdba007892" />


## Things Learned
- I don't have any sort of policy gem in this app. neat.
- i'd like to expand the concept of `published` into a `status` that is more manageable. I added a task for it #1166 

## Due Diligence Checks

- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [ ] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
