### PR TITLE
Replace  surveys.published column with status

### DIFF
--- a/app/controllers/admin/surveys_controller.rb
+++ b/app/controllers/admin/surveys_controller.rb
@@ -15,6 +15,6 @@ class Admin::SurveysController < AdminController
   end
 
   def survey_params
-    params.require(:survey).permit(:name, :description, :published, :available_to_public)
+    params.require(:survey).permit(:name, :description, :status, :available_to_public)
   end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -10,7 +10,7 @@
 #  calculated_question_min_points :integer
 #  description                    :text
 #  name                           :string           not null
-#  published                      :boolean          default(FALSE), not null
+#  status                         :integer          default("draft"), not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  user_id                        :bigint
@@ -28,6 +28,8 @@ class Survey < ApplicationRecord
   # For example, an admin might create a "Depression Survey" with questions about mood,
   # sleep, appetite, etc. The user can then fill out the survey on a regular basis to track
   # their symptoms and share the results with their therapist.
+
+  enum :status, {draft: 0, published: 1, archived: 2}
 
   belongs_to :author, class_name: "User", optional: true, foreign_key: "user_id"
 
@@ -53,7 +55,7 @@ class Survey < ApplicationRecord
     numericality: {only_integer: true, greater_than_or_equal_to: ->(record) { record.calculated_question_min_points || 0 }},
     allow_nil: true
 
-  scope :published, -> { where(published: true) }
+  # This scope is to differentiate between surveys that users create for themselves vs ones created by admins for other users to take.
   scope :available_to_public, -> { where(available_to_public: true) }
 
   def max_score

--- a/app/views/admin/surveys/index.html.erb
+++ b/app/views/admin/surveys/index.html.erb
@@ -17,7 +17,7 @@
     <div class="row border-bottom mb-0">
       <div class="col-2 py-1 px-2"><%= link_to survey.name, admin_survey_path(survey) %></div>
       <div class="col-4 py-1 px-2"><%= survey.description %></div>
-      <div class="col-1 py-1 px-2"><%= survey.published? ? "Published" : "Draft" %></div>
+      <div class="col-1 py-1 px-2"><%= survey.status %></div>
       <div class="col-2 py-1 px-2"><%= survey.responses.size %></div>
       <div class="col-3 py-1 px-2">
         <!-- TODO: use policies to display available action buttons -->

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -1,6 +1,8 @@
 <% content_for(:title, @survey.name) %>
 
-<h1><%= @survey.name.titleize %> <span class="fs-6 text"><%= @survey.published? ? "(Published)" : "(Draft)" %></span></h1>
+<%= link_to 'back to surveys', admin_surveys_path %>
+
+<h1><%= @survey.name.titleize %> <span class="fs-6 text">(<%= @survey.status %>)</span></h1>
 <p><%= @survey.description %></p>    
 <div class="row">
   <div class="col-7">

--- a/db/migrate/20260424153043_add_status_to_surveys.rb
+++ b/db/migrate/20260424153043_add_status_to_surveys.rb
@@ -1,0 +1,5 @@
+class AddStatusToSurveys < ActiveRecord::Migration[8.1]
+  def change
+    add_column :surveys, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260424153448_drop_published_from_surveys.rb
+++ b/db/migrate/20260424153448_drop_published_from_surveys.rb
@@ -1,0 +1,5 @@
+class DropPublishedFromSurveys < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :surveys, :published, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_175044) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_153448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -262,7 +262,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_175044) do
     t.datetime "created_at", null: false
     t.text "description"
     t.string "name", null: false
-    t.boolean "published", default: false, null: false
+    t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_surveys_on_user_id"

--- a/lib/tasks/seed/surveys.rake
+++ b/lib/tasks/seed/surveys.rake
@@ -26,7 +26,7 @@ namespace :db do
         user_id: user.id,
         name: "Depression Checklist",
         description: "A survey to track symptoms of depression over time.",
-        published: true,
+        status: :published,
         available_to_public: false
       )
 

--- a/spec/factories/surveys.rb
+++ b/spec/factories/surveys.rb
@@ -10,7 +10,7 @@
 #  calculated_question_min_points :integer
 #  description                    :text
 #  name                           :string           not null
-#  published                      :boolean          default(FALSE), not null
+#  status                         :integer          default("draft"), not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  user_id                        :bigint
@@ -29,7 +29,7 @@ FactoryBot.define do
     sequence(:description) { |n| "survey#{n} description" }
     calculated_question_min_points { nil }
     calculated_question_max_points { nil }
-    published { false }
+    status { :draft }
     available_to_public { false }
   end
 end

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -10,7 +10,7 @@
 #  calculated_question_min_points :integer
 #  description                    :text
 #  name                           :string           not null
-#  published                      :boolean          default(FALSE), not null
+#  status                         :integer          default("draft"), not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  user_id                        :bigint
@@ -66,18 +66,6 @@ RSpec.describe Survey, type: :model do
       survey = build(:survey, name: "EXAMPLE survey")
       expect(survey.valid?).to be(true)
       expect(survey.name).to eq("EXAMPLE survey")
-    end
-  end
-
-  describe "scope: published" do
-    let(:subject) { Survey.published }
-
-    it "returns only surveys where published is true" do
-      published_survey = create(:survey, published: true)
-      unpublished_survey = create(:survey, published: false)
-
-      expect(subject).to eq([published_survey])
-      expect(subject).not_to include(unpublished_survey)
     end
   end
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #1166

## Problems Solved
- allows complex state management of a survey's `status` instead of a simple `published` boolean
- there was no need for a data migration because there are no existing survey objects

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
