### PR TITLE
Add action policy gem for authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,10 +24,14 @@ gem "turbo-rails"
 gem "stimulus-rails"
 
 gem "bootsnap", require: false
-gem "chartkick" # chart rendering for ruby data https://chartkick.com/
 gem "devise" # user authentication
+gem "action_policy" # authorization. see: https://github.com/palkan/action_policy
+
+# View helpers
+gem "chartkick" # chart rendering for ruby data https://chartkick.com/
 gem "groupdate" # grouping by dates. goes with chartkick
 gem "will_paginate", "~> 4.0.1" # pagination. Styles: http://mislav.github.io/will_paginate/
+gem "draper" # decorator facilitation
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"
@@ -49,7 +53,6 @@ gem "tzinfo-data", platforms: %i[windows jruby]
 
 gem "sentry-rails"                      # Rails support for Sentry
 gem "sentry-ruby"  # Error reporting to Sentry.io
-gem "draper" # decorator facilitation
 
 group :development do
   gem "annot8" # A fork of gem `annotate` that is Rails 8 compatible. Annotate models, routes, etc. with schema info

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    action_policy (0.7.6)
+      ruby-next-core (>= 1.0)
     action_text-trix (2.1.18)
       railties
     actioncable (8.1.3)
@@ -474,6 +476,7 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-graphviz (1.2.5)
       rexml
+    ruby-next-core (1.2.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     ruby_parser (3.22.0)
@@ -612,6 +615,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  action_policy
   annot8
   awesome_print
   better_errors
@@ -666,6 +670,7 @@ DEPENDENCIES
   will_paginate (~> 4.0.1)
 
 CHECKSUMS
+  action_policy (0.7.6) sha256=a80156671e6b7784a2f1fa3a5f347da27c7e13abe7b1c9aab81772839794002d
   action_text-trix (2.1.18) sha256=3fdb83f8bff4145d098be283cdd47ac41caf5110bfa6df4695ed7127d7fb3642
   actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0
   actionmailbox (8.1.3) sha256=df7da474eaa0e70df4ed5a6fef66eb3b3b0f2dbf7f14518deee8d77f1b4aae59
@@ -840,6 +845,7 @@ CHECKSUMS
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   ruby-graphviz (1.2.5) sha256=1c2bb44e3f6da9e2b829f5e7fd8d75a521485fb6b4d1fc66ff0f93f906121504
+  ruby-next-core (1.2.0) sha256=f6a7d00bb5186cecbb02f7f1845a0f3a2c9788d35b6ccff5c9be3f0d46799b86
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23

--- a/app/controllers/admin/surveys_controller.rb
+++ b/app/controllers/admin/surveys_controller.rb
@@ -1,11 +1,48 @@
 class Admin::SurveysController < AdminController
-  before_action :set_survey, only: [:show]
+  before_action :set_survey, only: [:show, :publish, :archive, :make_public, :make_private, :destroy]
 
   def index
-    @surveys = Survey.all
+    @surveys = current_user.surveys.all
+    @public_surveys = Survey.where(available_to_public: true).where.not(user_id: current_user.id)
   end
 
   def show
+    authorize! @survey
+  end
+
+  def publish
+    authorize! @survey
+
+    @survey.published!
+    redirect_to admin_survey_path(@survey), notice: "Survey published successfully."
+  end
+
+  def archive
+    authorize! @survey
+
+    @survey.archived!
+    redirect_to admin_survey_path(@survey), notice: "Survey archived successfully."
+  end
+
+  def make_public
+    authorize! @survey
+
+    @survey.update(available_to_public: true)
+    redirect_to admin_survey_path(@survey), notice: "Survey is now public."
+  end
+
+  def make_private
+    authorize! @survey, :make_private?
+
+    @survey.update(available_to_public: false)
+    redirect_to admin_survey_path(@survey), notice: "Survey is now private."
+  end
+
+  def destroy
+    authorize! @survey, :destroy?
+
+    @survey.destroy
+    redirect_to admin_surveys_path, notice: "Survey deleted successfully."
   end
 
   private

--- a/app/controllers/admin/surveys_controller.rb
+++ b/app/controllers/admin/surveys_controller.rb
@@ -32,14 +32,14 @@ class Admin::SurveysController < AdminController
   end
 
   def make_private
-    authorize! @survey, :make_private?
+    authorize! @survey
 
     @survey.update(available_to_public: false)
     redirect_to admin_survey_path(@survey), notice: "Survey is now private."
   end
 
   def destroy
-    authorize! @survey, :destroy?
+    authorize! @survey
 
     @survey.destroy
     redirect_to admin_surveys_path, notice: "Survey deleted successfully."

--- a/app/policies/admin/survey_policy.rb
+++ b/app/policies/admin/survey_policy.rb
@@ -1,0 +1,57 @@
+class Admin::SurveyPolicy < ApplicationPolicy
+  # See https://actionpolicy.evilmartians.io/#/writing_policies
+  #
+  # Scoping
+  # See https://actionpolicy.evilmartians.io/#/scoping
+  #
+  # relation_scope do |relation|
+  #   next relation if user.admin?
+  #   relation.where(user: user)
+  # end
+
+  def index?
+    admin?
+  end
+
+  def new?
+    admin?
+  end
+
+  def show?
+    admin? && owner_or_public?
+  end
+
+  def edit?
+    admin? && owner_or_public? && record.draft?
+  end
+
+  def update?
+    admin? && owner_or_public? && record.draft?
+  end
+
+  def destroy?
+    admin? && owner_or_public? && record.draft?
+  end
+
+  def publish?
+    admin? && owner_or_public? && (record.draft? || record.archived?)
+  end
+
+  def archive?
+    admin? && owner_or_public? && record.published?
+  end
+
+  def make_public?
+    admin? && owner_or_public? && record.published? && !record.available_to_public?
+  end
+
+  def make_private?
+    admin? && owner_or_public? && record.published? && record.available_to_public?
+  end
+
+  private
+
+  def owner_or_public?
+    record.available_to_public? || owner?
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,23 @@
+# Base class for application policies
+class ApplicationPolicy < ActionPolicy::Base
+  # Configure additional authorization contexts here
+  # (`user` is added by default).
+  #
+  #   authorize :account, optional: true
+  #
+  # Read more about authorization context: https://actionpolicy.evilmartians.io/#/authorization_context
+
+  private
+
+  def owner?
+    record.user_id == user.id
+  end
+
+  def admin?
+    user.admin?
+  end
+
+  def owner_or_admin?
+    owner? || admin?
+  end
+end

--- a/app/policies/survey_policy.rb
+++ b/app/policies/survey_policy.rb
@@ -1,0 +1,26 @@
+class SurveyPolicy < ApplicationPolicy
+  # See https://actionpolicy.evilmartians.io/#/writing_policies
+  #
+  # Scoping
+  # See https://actionpolicy.evilmartians.io/#/scoping
+  #
+  # relation_scope do |relation|
+  #   next relation if user.admin?
+  #   relation.where(user: user)
+  # end
+
+  def index?
+    admin?
+  end
+
+  def show?
+    admin?
+  end
+
+  private
+
+  # Will be in-use when we allow non-admin users to create public surveys
+  def owner_or_public?
+    record.available_to_public? || owner?
+  end
+end

--- a/app/views/admin/surveys/_action_buttons.html.erb
+++ b/app/views/admin/surveys/_action_buttons.html.erb
@@ -1,0 +1,6 @@
+<%= link_to "Edit", edit_admin_survey_path(survey), class: "btn btn-sm btn-primary" if allowed_to?(:edit?, survey) %>
+<%= button_to "Publish", publish_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary display-block" if allowed_to?(:publish?, survey) %>
+<%= button_to "Archive", archive_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:archive?, survey) %>
+<%= button_to "Make Public", make_public_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:make_public?, survey) %>
+<%= button_to "Make Private", make_private_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:make_private?, survey) %>
+<%= link_to "Delete", admin_survey_path(survey), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, survey) %>

--- a/app/views/admin/surveys/index.html.erb
+++ b/app/views/admin/surveys/index.html.erb
@@ -19,12 +19,8 @@
       <div class="col-4 py-1 px-2"><%= survey.description %></div>
       <div class="col-1 py-1 px-2"><%= survey.status %></div>
       <div class="col-2 py-1 px-2"><%= survey.responses.size %></div>
-      <div class="col-3 py-1 px-2">
-        <!-- TODO: use policies to display available action buttons -->
-        <%#= link_to "Edit", edit_admin_survey_path(survey), class: "btn btn-sm btn-primary" %>
-        <%= link_to "Publish", '#', class: "btn btn-sm btn-primary" %>
-        <%= link_to "Archive", '#', class: "btn btn-sm btn-primary" %>
-        <%#= link_to "Delete", admin_survey_path(survey), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-danger" unless survey.published? %>
+      <div class="col-3 py-1 px-2 d-flex justify-content-start align-items-start gap-1">
+        <%= render partial: "action_buttons", locals: {survey: survey} %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -2,8 +2,14 @@
 
 <%= link_to 'back to surveys', admin_surveys_path %>
 
-<h1><%= @survey.name.titleize %> <span class="fs-6 text">(<%= @survey.status %>)</span></h1>
-<p><%= @survey.description %></p>    
+<div class="d-flex justify-content-between">
+  <h1><%= @survey.name.titleize %> <span class="fs-6 text">(<%= @survey.status %>)</span></h1>
+  <div class="d-flex justify-content-end align-items-start gap-1">
+    <%= render partial: "action_buttons", locals: {survey: @survey} %>
+  </div>
+</div>
+<p><%= @survey.description %></p> 
+
 <div class="row">
   <div class="col-7">
     <h2 class="fs-4 text">Questions</h2>
@@ -26,10 +32,6 @@
     </ul>
   </div>
 </div>
-
-
-
-
 
 <h2 class="fs-4 text">Score Interpretation</h2>
 <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,14 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users, only: [:index, :show]  # existing
-    resources :surveys
+    resources :surveys do
+      member do
+        post :publish
+        post :archive
+        post :make_public
+        post :make_private
+      end
+    end
   end
 
   resources :users, only: [:update]

--- a/spec/policies/admin/survey_policy_spec.rb
+++ b/spec/policies/admin/survey_policy_spec.rb
@@ -1,0 +1,478 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::SurveyPolicy, type: :policy do
+  let(:user) { build_stubbed(:user, admin: false) }
+  let(:other_user) { build_stubbed(:user, admin: false) }
+  let(:admin_user) { build_stubbed(:user, admin: true) }
+  let(:context) { {user: current_user} }
+
+  let(:policy) { described_class.new(record, user: current_user) }
+
+  describe "#index?" do
+    subject { policy.apply(:index?) }
+
+    let(:record) { build_stubbed(:survey) }
+
+    context "when the current_user is an admin" do
+      let(:current_user) { admin_user }
+
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is NOT an admin" do
+      let(:current_user) { other_user }
+
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#new?" do
+    subject { policy.apply(:new?) }
+
+    let(:record) { build_stubbed(:survey) }
+
+    context "when the current_user is an admin" do
+      let(:current_user) { admin_user }
+
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is NOT an admin" do
+      let(:current_user) { other_user }
+
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#show?" do
+    subject { policy.apply(:show?) }
+
+    context "when the current_user is not an admin but they own the record" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, user_id: other_user.id) }
+
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is not an admin and the survey is available to public" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, available_to_public: true, user_id: user.id) }
+
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin" do
+      let(:current_user) { admin_user }
+
+      context "and the current_user is the owner but the survey is not available to the public" do
+        let(:record) { build_stubbed(:survey, available_to_public: false, user_id: current_user.id) }
+
+        it "returns true" do
+          is_expected.to eq(true)
+        end
+      end
+
+      context "and the current_user is not the owner but the survey is available to the public" do
+        let(:record) { build_stubbed(:survey, available_to_public: true, user_id: other_user.id) }
+
+        it "returns true" do
+          is_expected.to eq(true)
+        end
+      end
+
+      context "but the current_user is not the owner and the survey is not available to the public" do
+        let(:record) { build_stubbed(:survey, available_to_public: false, user_id: other_user.id) }
+
+        it "returns false" do
+          is_expected.to eq(false)
+        end
+      end
+    end
+
+    context "when the current_user is the owner" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, available_to_public: false, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the survey is available to the public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, available_to_public: true, user_id: other_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the survey is not available to the public and the user is not the owner" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, available_to_public: false, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#edit?" do
+    subject { policy.apply(:edit?) }
+
+    context "when the current_user is an admin and owns the survey and it is a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin and does not own the survey but the survey is public and a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin but does not own the survey and the survey is not public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is archived" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :archived, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is not an admin" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#update?" do
+    subject { policy.apply(:update?) }
+
+    context "when the current_user is an admin and owns the survey and it is a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin and does not own the survey but the survey is public and a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin but does not own the survey and the survey is not public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is archived" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :archived, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is not an admin" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#destroy?" do
+    subject { policy.apply(:destroy?) }
+
+    context "when the current_user is an admin and owns the survey and it is a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin and does not own the survey but the survey is public and a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin but does not own the survey and the survey is not public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is archived" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :archived, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is not an admin" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#publish?" do
+    subject { policy.apply(:publish?) }
+
+    context "when the current_user is an admin and owns the survey and it is a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey and it is archived" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :archived, available_to_public: false, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin and does not own the survey but the survey is public and a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin but does not own the survey and the survey is not public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is already published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is not an admin" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#archive?" do
+    subject { policy.apply(:archive?) }
+
+    context "when the current_user is an admin and owns the survey and it is published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin and does not own the survey but the survey is public and published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: true, user_id: other_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin but does not own the survey and the survey is not public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is a draft" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is already archived" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :archived, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is not an admin" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: true, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#make_public?" do
+    subject { policy.apply(:make_public?) }
+
+    context "when the current_user is an admin and owns the survey and it is published and not yet public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin but does not own the survey and the survey is not yet public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is already public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: true, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is not published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is not an admin" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#make_private?" do
+    subject { policy.apply(:make_private?) }
+
+    context "when the current_user is an admin and owns the survey and it is published and currently public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: true, user_id: admin_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin and does not own the survey but the survey is public and published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: true, user_id: other_user.id) }
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is not public" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: false, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is an admin and owns the survey but it is not published" do
+      let(:current_user) { admin_user }
+      let(:record) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: admin_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+
+    context "when the current_user is not an admin" do
+      let(:current_user) { other_user }
+      let(:record) { build_stubbed(:survey, status: :published, available_to_public: true, user_id: other_user.id) }
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+end

--- a/spec/policies/survey_policy_spec.rb
+++ b/spec/policies/survey_policy_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SurveyPolicy, type: :policy do
+  let(:user) { build_stubbed(:user, admin: false) }
+  let(:other_user) { build_stubbed(:user, admin: false) }
+  let(:admin_user) { build_stubbed(:user, admin: true) }
+  let(:context) { {user: current_user} }
+
+  let(:policy) { described_class.new(record, user: current_user) }
+
+  describe "#index?" do
+    subject { policy.apply(:index?) }
+    let(:record) { build_stubbed(:survey) }
+
+    context "when the current_user is admin" do
+      let(:current_user) { admin_user }
+
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is not admin" do
+      let(:current_user) { other_user }
+
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
+  describe "#show?" do
+    subject { policy.apply(:show?) }
+    let(:record) { build_stubbed(:survey) }
+
+    context "when the current_user is admin" do
+      let(:current_user) { admin_user }
+
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is not admin" do
+      let(:current_user) { other_user }
+
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ require "rspec/rails"
 require "devise"
 require "capybara/rails"
 require "capybara/rspec"
+require "action_policy/rspec"
 
 require_relative "support/controller_macros"
 

--- a/spec/requests/admin/surveys_spec.rb
+++ b/spec/requests/admin/surveys_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Admin::Surveys", type: :request do
   let(:admin) { create(:user, admin: true) }
-  let(:survey) { create(:survey) }
+  let(:survey) { create(:survey, user_id: admin.id) }
 
   describe "unauthenticated access" do
     it "redirects index to sign in" do
@@ -14,6 +14,31 @@ RSpec.describe "Admin::Surveys", type: :request do
 
     it "redirects show to sign in" do
       get admin_survey_path(survey)
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects publish to sign in" do
+      post publish_admin_survey_path(survey)
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects archive to sign in" do
+      post archive_admin_survey_path(survey)
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects make_public to sign in" do
+      post make_public_admin_survey_path(survey)
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects make_private to sign in" do
+      post make_private_admin_survey_path(survey)
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects destroy to sign in" do
+      delete admin_survey_path(survey)
       expect(response).to redirect_to new_user_session_path
     end
 
@@ -58,16 +83,36 @@ RSpec.describe "Admin::Surveys", type: :request do
       expect(response).to redirect_to root_path
     end
 
-    # it "redirects new to root" do
-    #   get new_admin_survey_path
-    #   expect(response).to redirect_to root_path
-    # end
+    it "redirects publish to root" do
+      post publish_admin_survey_path(survey)
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects archive to root" do
+      post archive_admin_survey_path(survey)
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects make_public to root" do
+      post make_public_admin_survey_path(survey)
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects make_private to root" do
+      post make_private_admin_survey_path(survey)
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects destroy to root" do
+      delete admin_survey_path(survey)
+      expect(response).to redirect_to root_path
+    end
   end
 
   describe "admin access" do
     before { sign_in(admin) }
 
-    describe "GET /admin/surveys" do
+    describe "index: GET /admin/surveys" do
       it "renders successfully" do
         get admin_surveys_path
         expect(response).to be_successful
@@ -75,11 +120,70 @@ RSpec.describe "Admin::Surveys", type: :request do
       end
     end
 
-    describe "GET /admin/surveys/:id" do
-      it "renders successfully" do
+    describe "show: GET /admin/surveys/:id" do
+      it "renders successfully when the admin owns the survey" do
         get admin_survey_path(survey)
         expect(response).to be_successful
         expect(response).to render_template(:show)
+      end
+
+      it "renders successfully when the survey is public" do
+        public_survey = create(:survey, available_to_public: true)
+        get admin_survey_path(public_survey)
+        expect(response).to be_successful
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe "publish: POST /admin/surveys/:id/publish" do
+      it "publishes a draft survey owned by the admin and redirects to show" do
+        draft_survey = create(:survey, status: :draft, user_id: admin.id)
+        post publish_admin_survey_path(draft_survey)
+
+        expect(draft_survey.reload).to be_published
+        expect(response).to redirect_to admin_survey_path(draft_survey)
+      end
+    end
+
+    describe "archive: POST /admin/surveys/:id/archive" do
+      it "archives a published survey owned by the admin and redirects to show" do
+        published_survey = create(:survey, status: :published, user_id: admin.id)
+        post archive_admin_survey_path(published_survey)
+
+        expect(published_survey.reload).to be_archived
+        expect(response).to redirect_to admin_survey_path(published_survey)
+      end
+    end
+
+    describe "make_public: POST /admin/surveys/:id/make_public" do
+      it "makes a published survey public and redirects to show" do
+        published_survey = create(:survey, status: :published, available_to_public: false, user_id: admin.id)
+        post make_public_admin_survey_path(published_survey)
+
+        expect(published_survey.reload.available_to_public).to be true
+        expect(response).to redirect_to admin_survey_path(published_survey)
+      end
+    end
+
+    describe "make_private: POST /admin/surveys/:id/make_private" do
+      it "makes a public survey private and redirects to show" do
+        public_survey = create(:survey, status: :published, available_to_public: true, user_id: admin.id)
+        post make_private_admin_survey_path(public_survey)
+
+        expect(public_survey.reload.available_to_public).to be false
+        expect(response).to redirect_to admin_survey_path(public_survey)
+      end
+    end
+
+    describe "DELETE /admin/surveys/:id" do
+      it "destroys a draft survey owned by the admin and redirects to index" do
+        draft_survey = create(:survey, status: :draft, user_id: admin.id)
+
+        expect {
+          delete admin_survey_path(draft_survey)
+        }.to change(Survey, :count).by(-1)
+
+        expect(response).to redirect_to admin_surveys_path
       end
     end
 


### PR DESCRIPTION
## Related Issues & PRs
* realtes to #1153

## Problems Solved
- the new survey feature has some complex authorization rules around survey status and the codebase didn't have an authorization gem
- allows me greater control over specific controller actions and view conditions

## Things Learned
- `pre_check`s are fiddly things

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
