### PR TITLE
Create, edit, and destroy surveys

### DIFF
--- a/app/controllers/admin/surveys_controller.rb
+++ b/app/controllers/admin/surveys_controller.rb
@@ -1,13 +1,49 @@
 class Admin::SurveysController < AdminController
-  before_action :set_survey, only: [:show, :publish, :archive, :make_public, :make_private, :destroy]
+  before_action :set_survey, only: [:show, :edit, :update, :publish, :archive, :make_public, :make_private, :destroy]
 
   def index
     @surveys = current_user.surveys.all
     @public_surveys = Survey.where(available_to_public: true).where.not(user_id: current_user.id)
   end
 
+  def new
+    @survey = current_user.surveys.new
+  end
+
+  def create
+    @survey = current_user.surveys.new(survey_params)
+    authorize! @survey
+
+    if @survey.save
+      redirect_to admin_survey_path(@survey)
+    else
+      render :new
+    end
+  end
+
   def show
     authorize! @survey
+  end
+
+  def edit
+    authorize! @survey
+  end
+
+  def update
+    authorize! @survey
+
+    if @survey.update(survey_params)
+      redirect_to admin_survey_path(@survey)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    authorize! @survey
+
+    @survey.destroy
+    redirect_to admin_surveys_path, notice: "Survey deleted successfully."
   end
 
   def publish
@@ -36,13 +72,6 @@ class Admin::SurveysController < AdminController
 
     @survey.update(available_to_public: false)
     redirect_to admin_survey_path(@survey), notice: "Survey is now private."
-  end
-
-  def destroy
-    authorize! @survey
-
-    @survey.destroy
-    redirect_to admin_surveys_path, notice: "Survey deleted successfully."
   end
 
   private

--- a/app/policies/admin/survey_policy.rb
+++ b/app/policies/admin/survey_policy.rb
@@ -17,6 +17,10 @@ class Admin::SurveyPolicy < ApplicationPolicy
     admin?
   end
 
+  def create?
+    admin?
+  end
+
   def show?
     admin? && owner_or_public?
   end

--- a/app/views/admin/surveys/_action_buttons.html.erb
+++ b/app/views/admin/surveys/_action_buttons.html.erb
@@ -3,4 +3,4 @@
 <%= button_to "Archive", archive_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:archive?, survey) %>
 <%= button_to "Make Public", make_public_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:make_public?, survey) %>
 <%= button_to "Make Private", make_private_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:make_private?, survey) %>
-<%= link_to "Delete", admin_survey_path(survey), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, survey) %>
+<%= button_to "Delete", admin_survey_path(survey), method: :delete, data: { turbo_confirm: "Are you sure you want to delete this survey?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, survey) %>

--- a/app/views/admin/surveys/_form.html.erb
+++ b/app/views/admin/surveys/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with model: [:admin, @survey], turbo: false do |form| %>
+  <%= render partial: 'shared/errors', locals: {object: @survey} %>
+  <div class="mb-3">
+    <%= form.label :name, class: 'required' %>
+    <%= form.text_field :name, class: 'form-control' %>
+  </div>
+  <div class="mb-3">
+    <%= form.label :description %>
+    <%= form.text_area :description, class: 'form-control' %>
+  </div>
+  <% if form.object.persisted? %>
+    <%= form.submit class: button_class('primary')  %>
+  <% else %>
+    <%= form.submit 'Continue', class: button_class('primary') %>
+  <% end %>
+<% end %>

--- a/app/views/admin/surveys/edit.html.erb
+++ b/app/views/admin/surveys/edit.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:title, "Editing #{@survey.name}") %>
+
+
+<div class="d-flex justify-content-between align-items-start mb-3">
+  <h1>Editing <%= @survey.name.titleize %></h1>
+  <%= link_to 'Cancel', admin_surveys_path, class: button_class('secondary') %>
+</div>
+<%= render partial: 'admin/surveys/form', locals: { survey: @survey } %>

--- a/app/views/admin/surveys/index.html.erb
+++ b/app/views/admin/surveys/index.html.erb
@@ -1,8 +1,9 @@
 <% content_for(:title, "Manage Surveys") %>
 
-<%#= link_to 'New Survey', new_admin_survey_path, class: button_class('primary pull-right') %>
-
-<h1>Manage Surveys</h1>
+<div class="d-flex justify-content-between align-items-start mb-3">
+  <h1>Manage Surveys</h1>
+  <%= link_to 'New Survey', new_admin_survey_path, class: button_class('primary') %>
+</div>
 
 <div class="container w-100 overflow-x-scroll">
   <div class="row fw-bolder border-bottom border-top mb-0 text-bg-light">

--- a/app/views/admin/surveys/new.html.erb
+++ b/app/views/admin/surveys/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:title, "Create a Survey") %>
+
+<div class="d-flex justify-content-between align-items-start mb-3">
+  <h1>New Survey</h1>
+  <%= link_to 'Cancel', admin_surveys_path, class: button_class('secondary') %>
+</div>
+
+<%= render partial: 'admin/surveys/form', locals: { survey: @survey } %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -1,20 +1,27 @@
 <% content_for(:title, @survey.name) %>
 
-<%= link_to 'back to surveys', admin_surveys_path %>
-
 <div class="d-flex justify-content-between">
   <h1><%= @survey.name.titleize %> <span class="fs-6 text">(<%= @survey.status %>)</span></h1>
   <div class="d-flex justify-content-end align-items-start gap-1">
+    <%= link_to 'Back to Surveys', admin_surveys_path, class: button_class('secondary') %>
     <%= render partial: "action_buttons", locals: {survey: @survey} %>
   </div>
 </div>
 <p><%= @survey.description %></p> 
 
-<div class="row">
+<div class="row mb-3">
   <div class="col-7">
     <h2 class="fs-4 text">Questions</h2>
+    <%= link_to 'Add Question Category', new_admin_survey_survey_category_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+    <%= tag.div id: "js_survey_question_form", data: {controller: "clearable" } %>
+
+    <%= render partial: "admin/survey/categories/form", locals: {survey: @survey} %>
+    
     <% @survey.categories.each do |category| %>
       <h3 class="fs-5 text"><%= category.name %></h3>
+      <%= link_to 'Add Question', new_admin_survey_category_survey_question_path(@survey, category), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+      <%= render partial: "admin/survey/questions/form", locals: {survey: @survey, category: category} %>
+      
       <ul>
         <% category.questions.each do |question| %>
           <li><%= question.position %>: <%= question.text %></li>
@@ -25,15 +32,17 @@
 
   <div class="col-5">
     <h2 class="fs-4 text">Answer Options</h2>
-    <ul>
-      <% @survey.answer_options.each do |option| %>
-        <li><%= option.value %>: <%= option.name %></li>
-      <% end %>
-    </ul>
+    <%= link_to '+ Add', new_admin_survey_survey_answer_option_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+    <%= tag.div id: "js_survey_answer_option_form", data: {controller: "clearable" } %>
+    <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
   </div>
 </div>
 
 <h2 class="fs-4 text">Score Interpretation</h2>
+<%= link_to 'Add Score Range Step', new_admin_survey_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+<%= render partial: "admin/survey/score_range_steps/form", locals: {survey: @survey} %>
+<%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
+
 <ul>
   <% @survey.score_range_steps.each do |step| %>
     <li><strong><%= step.calculated_range_min_points %>-<%= step.calculated_range_max_points %>: <%= step.name %></strong> - <%= step.description %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,15 @@ Rails.application.routes.draw do
   root to: "logs#index"
 
   namespace :admin do
-    resources :users, only: [:index, :show]  # existing
-    resources :surveys do
+    resources :users, only: [:index, :show]
+    resources :surveys, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
+      resources :survey_categories, shallow: true do
+        resources :survey_questions, shallow: true
+      end
+      namespace :survey do
+        resources :answer_options
+        resources :score_range_steps
+      end
       member do
         post :publish
         post :archive

--- a/spec/policies/admin/survey_policy_spec.rb
+++ b/spec/policies/admin/survey_policy_spec.rb
@@ -54,6 +54,28 @@ RSpec.describe Admin::SurveyPolicy, type: :policy do
     end
   end
 
+  describe "#create?" do
+    subject { policy.apply(:create?) }
+
+    let(:record) { build_stubbed(:survey) }
+
+    context "when the current_user is an admin" do
+      let(:current_user) { admin_user }
+
+      it "returns true" do
+        is_expected.to eq(true)
+      end
+    end
+
+    context "when the current_user is NOT an admin" do
+      let(:current_user) { other_user }
+
+      it "returns false" do
+        is_expected.to eq(false)
+      end
+    end
+  end
+
   describe "#show?" do
     subject { policy.apply(:show?) }
 


### PR DESCRIPTION
## Related Issues & PRs
* #1152 
* #1153 
* Closes #1174

## Problems Solved
- Allows admin users to create, edit, destroy surveys
- Sets up the survey show page to be the hub for editing instead of making a big mega form
- Adds policies to ensure editing surveys only happens during safe survey statuses

## Screenshots
Creating a new survey
<img width="1260" height="809" alt="new_survey" src="https://github.com/user-attachments/assets/3b350710-1c28-467e-8cac-96e899f269b4" />

Editing a survey
<img width="1260" height="809" alt="edit_survey" src="https://github.com/user-attachments/assets/b6f28a9a-3339-4e98-9057-945814d4137e" />

Deleting a survey
<img width="1260" height="809" alt="delete_survey" src="https://github.com/user-attachments/assets/20fa0349-9626-4ad0-8d0e-12ef21e62961" />

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [ ] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
