### PR TITLE
CRUD for survey answer options

### DIFF
--- a/app/controllers/admin/survey/answer_options_controller.rb
+++ b/app/controllers/admin/survey/answer_options_controller.rb
@@ -1,0 +1,75 @@
+class Admin::Survey::AnswerOptionsController < AdminController
+  before_action :set_answer_option, only: [:edit, :update, :destroy]
+  before_action :set_survey, only: [:new, :create, :edit, :update, :destroy]
+
+  def new
+    @answer_option = @survey.answer_options.new
+    authorize! @answer_option
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def create
+    @answer_option = Survey::AnswerOption.new(answer_option_params)
+    authorize! @answer_option
+
+    respond_to do |format|
+      if @answer_option.save
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Answer option was successfully created." }
+      else
+        format.turbo_stream { render :new }
+        format.html { render :new, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def edit
+    authorize! @answer_option
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def update
+    authorize! @answer_option
+
+    respond_to do |format|
+      if @answer_option.update(answer_option_params)
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Answer option was successfully updated." }
+      else
+        format.turbo_stream { render :edit }
+        format.html { render :edit, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def destroy
+    authorize! @answer_option
+
+    respond_to do |format|
+      if @answer_option.destroy
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "#{@answer_option.name} was successfully destroyed." }
+      end
+    end
+  end
+
+  private
+
+  def set_survey
+    @survey = Survey.find(params[:survey_id])
+  end
+
+  def set_answer_option
+    @answer_option = Survey::AnswerOption.find(params[:id])
+  end
+
+  def answer_option_params
+    params.require(:survey_answer_option).permit(:name, :value, :survey_id)
+  end
+end

--- a/app/javascript/controllers/clearable_controller.js
+++ b/app/javascript/controllers/clearable_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  clear() {
+    // this.element.remove();
+    this.element.innerHTML = '';
+  }
+}

--- a/app/policies/admin/survey/answer_option_policy.rb
+++ b/app/policies/admin/survey/answer_option_policy.rb
@@ -1,0 +1,21 @@
+class Admin::Survey::AnswerOptionPolicy < ApplicationPolicy
+  def new?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def create?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def edit?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def update?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def destroy?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+end

--- a/app/views/admin/survey/answer_options/_form.html.erb
+++ b/app/views/admin/survey/answer_options/_form.html.erb
@@ -1,0 +1,32 @@
+<div class="container">
+  <div class="row border-top border-bottom mb-3">
+    <div class="col p-2 border-end border-start bg-light">  
+      <%= form_with model: [:admin, survey, answer_option], html: { novalidate: true } do |form| %>
+        
+        <%= render 'shared/errors', object: answer_option %>
+        <%= form.hidden_field :survey_id, value: survey.id %>
+
+        <div class="row">
+          <div class="col-3">
+            <div class="mb-3">
+              <%= form.label :value, class: "required" %>
+              <%= form.number_field :value, required: true, class: 'form-control' %>
+            </div>
+          </div>
+          <div class="col-9">
+            <div class="mb-3">
+              <%= form.label :name, class: "required" %>
+              <%= form.text_field :name, required: true, class: 'form-control' %>
+            </div>
+          </div>
+        </div>
+
+        <div class="actions d-flex justify-content-end align-items-start gap-2">
+          <%= button_tag "Cancel", type: "button", data: { action: "clearable#clear" }, class: button_class('secondary') %>
+          <%= form.submit "Submit", class: button_class('success') %>      
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/admin/survey/answer_options/_list.html.erb
+++ b/app/views/admin/survey/answer_options/_list.html.erb
@@ -1,0 +1,11 @@
+<div id="js_survey_answer_options_list">
+  <% @survey.answer_options.each do |option| %>
+    <div class="d-flex justify-content-between border-bottom py-2">
+      <div><%= option.value %>: <%= option.name %></div>
+      <div>
+        <%= link_to 'Edit', edit_admin_survey_survey_answer_option_path(@survey, option), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, option) %>
+        <%= link_to "Delete", admin_survey_survey_answer_option_path(@survey, option), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer option?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, option) %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/survey/answer_options/create.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/create.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_answer_option_form", "" %>
+
+<%= turbo_stream.replace "js_survey_answer_options_list" do %>
+  <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/answer_options/destroy.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/destroy.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_answer_option_form", "" %>
+
+<%= turbo_stream.replace "js_survey_answer_options_list" do %>
+  <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/answer_options/edit.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/edit.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "js_survey_answer_option_form" do %>
+  <%= render partial: "admin/survey/answer_options/form", locals: {survey: @answer_option.survey, answer_option: @answer_option} %>
+<% end %>

--- a/app/views/admin/survey/answer_options/new.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/new.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "js_survey_answer_option_form" do %>
+  <%= render partial: "admin/survey/answer_options/form", locals: {survey: @survey, answer_option: @answer_option} %>
+<% end %>

--- a/app/views/admin/survey/answer_options/update.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_answer_option_form", "" %>
+
+<%= turbo_stream.replace "js_survey_answer_options_list" do %>
+  <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
+<% end %>

--- a/spec/policies/admin/survey/answer_option_policy_spec.rb
+++ b/spec/policies/admin/survey/answer_option_policy_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Survey::AnswerOptionPolicy, type: :policy do
+  let(:admin_user) { build_stubbed(:user, admin: true) }
+  let(:other_user) { build_stubbed(:user, admin: false) }
+  let(:policy) { described_class.new(record, user: current_user) }
+
+  # All rules delegate to Admin::SurveyPolicy#edit?, so we only need to verify
+  # the delegation is wired up correctly — not re-test all survey policy combinations.
+
+  context "when Admin::SurveyPolicy permits edit (admin who owns a draft survey)" do
+    let(:current_user) { admin_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+    let(:record) { build_stubbed(:survey_answer_option, survey: survey) }
+
+    it "permits new?" do
+      expect(policy.apply(:new?)).to eq(true)
+    end
+
+    it "permits create?" do
+      expect(policy.apply(:create?)).to eq(true)
+    end
+
+    it "permits edit?" do
+      expect(policy.apply(:edit?)).to eq(true)
+    end
+
+    it "permits update?" do
+      expect(policy.apply(:update?)).to eq(true)
+    end
+
+    it "permits destroy?" do
+      expect(policy.apply(:destroy?)).to eq(true)
+    end
+  end
+
+  context "when Admin::SurveyPolicy denies edit (non-admin user)" do
+    let(:current_user) { other_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+    let(:record) { build_stubbed(:survey_answer_option, survey: survey) }
+
+    it "denies new?" do
+      expect(policy.apply(:new?)).to eq(false)
+    end
+
+    it "denies create?" do
+      expect(policy.apply(:create?)).to eq(false)
+    end
+
+    it "denies edit?" do
+      expect(policy.apply(:edit?)).to eq(false)
+    end
+
+    it "denies update?" do
+      expect(policy.apply(:update?)).to eq(false)
+    end
+
+    it "denies destroy?" do
+      expect(policy.apply(:destroy?)).to eq(false)
+    end
+  end
+end

--- a/spec/requests/admin/survey/answer_options_spec.rb
+++ b/spec/requests/admin/survey/answer_options_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:survey) { create(:survey, status: :draft, user_id: admin.id) }
+  let(:answer_option) { create(:survey_answer_option, survey: survey) }
+
+  # new and edit only respond to turbo_stream, so requests must include the Accept header
+  let(:turbo_stream_headers) { {"Accept" => "text/vnd.turbo-stream.html"} }
+
+  describe "unauthenticated access" do
+    it "redirects new to sign in" do
+      get new_admin_survey_survey_answer_option_path(survey), headers: turbo_stream_headers
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects create to sign in" do
+      post admin_survey_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Option", value: 1, survey_id: survey.id}}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects edit to sign in" do
+      get edit_admin_survey_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects update to sign in" do
+      patch admin_survey_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated"}}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects destroy to sign in" do
+      delete admin_survey_survey_answer_option_path(survey, answer_option)
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  describe "non-admin access" do
+    let(:non_admin) { create(:user, admin: false) }
+
+    before { sign_in(non_admin) }
+
+    it "redirects new to root" do
+      get new_admin_survey_survey_answer_option_path(survey), headers: turbo_stream_headers
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects create to root" do
+      post admin_survey_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Option", value: 1, survey_id: survey.id}}
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects edit to root" do
+      get edit_admin_survey_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects update to root" do
+      patch admin_survey_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated"}}
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects destroy to root" do
+      delete admin_survey_survey_answer_option_path(survey, answer_option)
+      expect(response).to redirect_to root_path
+    end
+  end
+
+  describe "admin access" do
+    before { sign_in(admin) }
+
+    describe "GET new" do
+      it "renders successfully" do
+        get new_admin_survey_survey_answer_option_path(survey), headers: turbo_stream_headers
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST create" do
+      context "with valid params" do
+        it "creates the answer option and redirects to the survey" do
+          expect {
+            post admin_survey_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Mild", value: 1, survey_id: survey.id}}
+          }.to change(Survey::AnswerOption, :count).by(1)
+
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not create the answer option" do
+          expect {
+            post admin_survey_survey_answer_options_path(survey), params: {survey_answer_option: {name: "", value: nil, survey_id: survey.id}}
+          }.not_to change(Survey::AnswerOption, :count)
+        end
+      end
+    end
+
+    describe "GET edit" do
+      it "renders successfully" do
+        get edit_admin_survey_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
+        expect(response).to be_successful
+      end
+    end
+
+    describe "PATCH update" do
+      context "with valid params" do
+        it "updates the answer option and redirects to the survey" do
+          patch admin_survey_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated Name"}}
+
+          expect(answer_option.reload.name).to eq("Updated Name")
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not update the answer option" do
+          original_name = answer_option.name
+          patch admin_survey_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: ""}}
+
+          expect(answer_option.reload.name).to eq(original_name)
+        end
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "destroys the answer option and redirects to the survey" do
+        answer_option_to_delete = create(:survey_answer_option, survey: survey)
+
+        expect {
+          delete admin_survey_survey_answer_option_path(survey, answer_option_to_delete)
+        }.to change(Survey::AnswerOption, :count).by(-1)
+
+        expect(response).to redirect_to admin_survey_path(survey)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
* #1152
* #1153
* Closes #1175

## Problems Solved
- adds CRUD for survery answer options from the survey show page
- users can interact with these values dynamically without leaving the show page

## Screenshots
<img width="1260" height="809" alt="option_add" src="https://github.com/user-attachments/assets/c3224b5d-23d6-4ba2-8e96-bef318e6c587" />


## Things Learned
I accidentally let some files slip into PR #1173
* the new answer options policy & specs
* the changes to the survey show page

## Due Diligence Checks

- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [ ] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
