### PR TITLE
CRUD for admin survey score range steps

### DIFF
--- a/app/controllers/admin/survey/score_range_steps_controller.rb
+++ b/app/controllers/admin/survey/score_range_steps_controller.rb
@@ -1,0 +1,75 @@
+class Admin::Survey::ScoreRangeStepsController < AdminController
+  before_action :set_score_range_step, only: [:edit, :update, :destroy]
+  before_action :set_survey, only: [:new, :create, :edit, :update, :destroy]
+
+  def new
+    @score_range_step = @survey.score_range_steps.new
+    authorize! @score_range_step
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def create
+    @score_range_step = Survey::ScoreRangeStep.new(score_range_step_params)
+    authorize! @score_range_step
+
+    respond_to do |format|
+      if @score_range_step.save
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Score range step was successfully created." }
+      else
+        format.turbo_stream { render :new }
+        format.html { render :new, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def edit
+    authorize! @score_range_step
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def update
+    authorize! @score_range_step
+
+    respond_to do |format|
+      if @score_range_step.update(score_range_step_params)
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Score range step was successfully updated." }
+      else
+        format.turbo_stream { render :edit }
+        format.html { render :edit, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def destroy
+    authorize! @score_range_step
+
+    respond_to do |format|
+      if @score_range_step.destroy
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "#{@score_range_step.name} was successfully destroyed." }
+      end
+    end
+  end
+
+  private
+
+  def set_survey
+    @survey = Survey.find(params[:survey_id])
+  end
+
+  def set_score_range_step
+    @score_range_step = Survey::ScoreRangeStep.find(params[:id])
+  end
+
+  def score_range_step_params
+    params.require(:survey_score_range_step).permit(:name, :position, :description, :survey_id)
+  end
+end

--- a/app/policies/admin/survey/score_range_step_policy.rb
+++ b/app/policies/admin/survey/score_range_step_policy.rb
@@ -1,0 +1,21 @@
+class Admin::Survey::ScoreRangeStepPolicy < ApplicationPolicy
+  def new?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy) && record.survey.questions.any?
+  end
+
+  def create?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy) && record.survey.questions.any?
+  end
+
+  def edit?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy) && record.survey.questions.any?
+  end
+
+  def update?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy) && record.survey.questions.any?
+  end
+
+  def destroy?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+end

--- a/app/views/admin/survey/score_range_steps/_form.html.erb
+++ b/app/views/admin/survey/score_range_steps/_form.html.erb
@@ -1,0 +1,40 @@
+<div class="container">
+  <div class="row border-top border-bottom mb-3">
+    <div class="col p-2 border-end border-start bg-light">  
+      <%= form_with model: [:admin, survey, score_range_step], html: { novalidate: true } do |form| %>
+        
+        <%= render 'shared/errors', object: score_range_step %>
+        <%= form.hidden_field :survey_id, value: survey.id %>
+
+        <div class="row">
+          <div class="col-3">
+            <div class="mb-3">
+              <%= form.label :position, class: "required" %>
+              <%= form.number_field :position, required: true, class: 'form-control' %>
+            </div>
+          </div>
+          <div class="col-9">
+            <div class="mb-3">
+              <%= form.label :name, class: "required" %>
+              <%= form.text_field :name, required: true, class: 'form-control' %>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-12">
+            <div class="mb-3">
+              <%= form.label :description %>
+              <%= form.text_area :description, class: 'form-control' %>
+            </div>
+          </div>
+        </div>
+
+        <div class="actions d-flex justify-content-end align-items-start gap-2">
+          <%= button_tag "Cancel", type: "button", data: { action: "clearable#clear" }, class: button_class('secondary') %>
+          <%= form.submit "Submit", class: button_class('success') %>      
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/admin/survey/score_range_steps/_list.html.erb
+++ b/app/views/admin/survey/score_range_steps/_list.html.erb
@@ -1,0 +1,11 @@
+<div id="js_survey_score_range_steps_list">
+  <% @survey.score_range_steps.each do |step| %>
+    <div class="d-flex justify-content-between border-bottom">
+      <div><strong><%= step.calculated_range_min_points %>-<%= step.calculated_range_max_points %>: <%= step.name %></strong> - <%= step.description %></div>
+      <div>
+        <%= link_to 'Edit', edit_admin_survey_survey_score_range_step_path(@survey, step), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, step) %>
+        <%= link_to "Delete", admin_survey_survey_score_range_step_path(@survey, step), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this score range step?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, step) %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/survey/score_range_steps/create.turbo_stream.erb
+++ b/app/views/admin/survey/score_range_steps/create.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_score_range_step_form", "" %>
+
+<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
+  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/score_range_steps/destroy.turbo_stream.erb
+++ b/app/views/admin/survey/score_range_steps/destroy.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_score_range_step_form", "" %>
+
+<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
+  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/score_range_steps/edit.turbo_stream.erb
+++ b/app/views/admin/survey/score_range_steps/edit.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "js_survey_score_range_step_form" do %>
+  <%= render partial: "admin/survey/score_range_steps/form", locals: {survey: @survey, score_range_step: @score_range_step} %>
+<% end %>

--- a/app/views/admin/survey/score_range_steps/new.turbo_stream.erb
+++ b/app/views/admin/survey/score_range_steps/new.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "js_survey_score_range_step_form" do %>
+  <%= render partial: "admin/survey/score_range_steps/form", locals: {survey: @survey, score_range_step: @score_range_step} %>
+<% end %>

--- a/app/views/admin/survey/score_range_steps/update.turbo_stream.erb
+++ b/app/views/admin/survey/score_range_steps/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_score_range_step_form", "" %>
+
+<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
+  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -39,13 +39,11 @@
 </div>
 
 <h2 class="fs-4 text">Score Interpretation</h2>
-<%= link_to 'Add Score Range Step', new_admin_survey_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
-<%= render partial: "admin/survey/score_range_steps/form", locals: {survey: @survey} %>
-<%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
-
-<ul>
-  <% @survey.score_range_steps.each do |step| %>
-    <li><strong><%= step.calculated_range_min_points %>-<%= step.calculated_range_max_points %>: <%= step.name %></strong> - <%= step.description %></li>
-  <% end %>
-</ul>
+<% if @survey.questions.any? %>
+  <%= link_to '+ Add', new_admin_survey_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+  <%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
+  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<% else %>
+  <p class="text">Add questions to the survey to enable score interpretation.</p>
+<% end %>
 

--- a/spec/policies/admin/survey/score_range_step_policy_spec.rb
+++ b/spec/policies/admin/survey/score_range_step_policy_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Survey::ScoreRangeStepPolicy, type: :policy do
+  let(:admin_user) { build_stubbed(:user, admin: true) }
+  let(:other_user) { build_stubbed(:user, admin: false) }
+  let(:policy) { described_class.new(record, user: current_user) }
+
+  # new?/create?/edit?/update? require survey policy edit? AND survey has questions.
+  # destroy? only requires survey policy edit?.
+
+  context "when the survey policy permits edit and the survey has questions" do
+    let(:current_user) { admin_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+    let(:record) { build_stubbed(:survey_score_range_step, survey: survey) }
+
+    before { allow(survey).to receive_message_chain(:questions, :any?).and_return(true) }
+
+    it "permits new?" do
+      expect(policy.apply(:new?)).to eq(true)
+    end
+
+    it "permits create?" do
+      expect(policy.apply(:create?)).to eq(true)
+    end
+
+    it "permits edit?" do
+      expect(policy.apply(:edit?)).to eq(true)
+    end
+
+    it "permits update?" do
+      expect(policy.apply(:update?)).to eq(true)
+    end
+
+    it "permits destroy?" do
+      expect(policy.apply(:destroy?)).to eq(true)
+    end
+  end
+
+  context "when the survey policy permits edit but the survey has no questions" do
+    let(:current_user) { admin_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+    let(:record) { build_stubbed(:survey_score_range_step, survey: survey) }
+
+    before { allow(survey).to receive_message_chain(:questions, :any?).and_return(false) }
+
+    it "denies new?" do
+      expect(policy.apply(:new?)).to eq(false)
+    end
+
+    it "denies create?" do
+      expect(policy.apply(:create?)).to eq(false)
+    end
+
+    it "denies edit?" do
+      expect(policy.apply(:edit?)).to eq(false)
+    end
+
+    it "denies update?" do
+      expect(policy.apply(:update?)).to eq(false)
+    end
+
+    it "still permits destroy?" do
+      expect(policy.apply(:destroy?)).to eq(true)
+    end
+  end
+
+  context "when the survey policy denies edit (non-admin user)" do
+    let(:current_user) { other_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+    let(:record) { build_stubbed(:survey_score_range_step, survey: survey) }
+
+    before { allow(survey).to receive_message_chain(:questions, :any?).and_return(true) }
+
+    it "denies new?" do
+      expect(policy.apply(:new?)).to eq(false)
+    end
+
+    it "denies create?" do
+      expect(policy.apply(:create?)).to eq(false)
+    end
+
+    it "denies edit?" do
+      expect(policy.apply(:edit?)).to eq(false)
+    end
+
+    it "denies update?" do
+      expect(policy.apply(:update?)).to eq(false)
+    end
+
+    it "denies destroy?" do
+      expect(policy.apply(:destroy?)).to eq(false)
+    end
+  end
+end

--- a/spec/requests/admin/survey/score_range_steps_spec.rb
+++ b/spec/requests/admin/survey/score_range_steps_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:survey) { create(:survey, status: :draft, user_id: admin.id) }
+  let(:score_range_step) { create(:survey_score_range_step, survey: survey) }
+
+  # The policy requires survey.questions.any? for new/create/edit/update
+  let(:category) { create(:survey_category, survey: survey) }
+  let(:question) { create(:survey_question, category: category) }
+  before do
+    category
+    question
+  end
+
+  # new and edit only respond to turbo_stream, so requests must include the Accept header
+  let(:turbo_stream_headers) { {"Accept" => "text/vnd.turbo-stream.html"} }
+
+  describe "unauthenticated access" do
+    it "redirects new to sign in" do
+      get new_admin_survey_survey_score_range_step_path(survey), headers: turbo_stream_headers
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects create to sign in" do
+      post admin_survey_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects edit to sign in" do
+      get edit_admin_survey_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects update to sign in" do
+      patch admin_survey_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated"}}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects destroy to sign in" do
+      delete admin_survey_survey_score_range_step_path(survey, score_range_step)
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  describe "non-admin access" do
+    let(:non_admin) { create(:user, admin: false) }
+
+    before { sign_in(non_admin) }
+
+    it "redirects new to root" do
+      get new_admin_survey_survey_score_range_step_path(survey), headers: turbo_stream_headers
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects create to root" do
+      post admin_survey_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects edit to root" do
+      get edit_admin_survey_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects update to root" do
+      patch admin_survey_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated"}}
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects destroy to root" do
+      delete admin_survey_survey_score_range_step_path(survey, score_range_step)
+      expect(response).to redirect_to root_path
+    end
+  end
+
+  describe "admin access" do
+    before { sign_in(admin) }
+
+    describe "GET new" do
+      it "renders successfully" do
+        get new_admin_survey_survey_score_range_step_path(survey), headers: turbo_stream_headers
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST create" do
+      context "with valid params" do
+        it "creates the score range step and redirects to the survey" do
+          expect {
+            post admin_survey_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
+          }.to change(Survey::ScoreRangeStep, :count).by(1)
+
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not create the score range step" do
+          expect {
+            post admin_survey_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "", position: nil, survey_id: survey.id}}
+          }.not_to change(Survey::ScoreRangeStep, :count)
+        end
+      end
+    end
+
+    describe "GET edit" do
+      it "renders successfully" do
+        get edit_admin_survey_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
+        expect(response).to be_successful
+      end
+    end
+
+    describe "PATCH update" do
+      context "with valid params" do
+        it "updates the score range step and redirects to the survey" do
+          patch admin_survey_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated Name"}}
+
+          expect(score_range_step.reload.name).to eq("Updated Name")
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not update the score range step" do
+          original_name = score_range_step.name
+          patch admin_survey_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: ""}}
+
+          expect(score_range_step.reload.name).to eq(original_name)
+        end
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "destroys the score range step and redirects to the survey" do
+        step_to_delete = create(:survey_score_range_step, survey: survey)
+
+        expect {
+          delete admin_survey_survey_score_range_step_path(survey, step_to_delete)
+        }.to change(Survey::ScoreRangeStep, :count).by(-1)
+
+        expect(response).to redirect_to admin_survey_path(survey)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
* #1152 
* #1153 
* Closes #1176

## Problems Solved
- Allows an admin to create score range steps
- Only allows this if the survey already has questions
- Uses turbo streams to accomplish everything

## Screenshots
If the survey has no questions, the user is prompted to add questions first
<img width="1252" height="462" alt="Screenshot 2026-04-28 at 3 23 20 PM" src="https://github.com/user-attachments/assets/c37a737d-e22e-42ba-9242-d83fb31d2f16" />

If the survey has questions, the user can do the CRUD
<img width="1260" height="809" alt="step_add" src="https://github.com/user-attachments/assets/33acc324-bee7-4860-aee9-4173d62c2d8d" />


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
