### PR TITLE
Reconfigure routes for survey children

### DIFF
--- a/app/views/admin/survey/answer_options/_form.html.erb
+++ b/app/views/admin/survey/answer_options/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row border-top border-bottom mb-3">
     <div class="col p-2 border-end border-start bg-light">  
-      <%= form_with model: [:admin, survey, answer_option], html: { novalidate: true } do |form| %>
+      <%= form_with model: [:admin, answer_option], html: { novalidate: true } do |form| %>
         
         <%= render 'shared/errors', object: answer_option %>
         <%= form.hidden_field :survey_id, value: survey.id %>

--- a/app/views/admin/survey/answer_options/_list.html.erb
+++ b/app/views/admin/survey/answer_options/_list.html.erb
@@ -1,4 +1,4 @@
-<div id="js_survey_answer_options_list">
+<div id="js_survey_answer_options_list" class="mt-3">
   <% @survey.answer_options.each do |option| %>
     <div class="d-flex justify-content-between border-bottom py-2">
       <div><%= option.value %>: <%= option.name %></div>

--- a/app/views/admin/survey/answer_options/_list.html.erb
+++ b/app/views/admin/survey/answer_options/_list.html.erb
@@ -3,8 +3,8 @@
     <div class="d-flex justify-content-between border-bottom py-2">
       <div><%= option.value %>: <%= option.name %></div>
       <div>
-        <%= link_to 'Edit', edit_admin_survey_survey_answer_option_path(@survey, option), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, option) %>
-        <%= link_to "Delete", admin_survey_survey_answer_option_path(@survey, option), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer option?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, option) %>
+        <%= link_to 'Edit', edit_admin_survey_answer_option_path(@survey, option), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, option) %>
+        <%= link_to "Delete", admin_survey_answer_option_path(@survey, option), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer option?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, option) %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/survey/score_range_steps/_form.html.erb
+++ b/app/views/admin/survey/score_range_steps/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row border-top border-bottom mb-3">
     <div class="col p-2 border-end border-start bg-light">  
-      <%= form_with model: [:admin, survey, score_range_step], html: { novalidate: true } do |form| %>
+      <%= form_with model: [:admin, score_range_step], html: { novalidate: true } do |form| %>
         
         <%= render 'shared/errors', object: score_range_step %>
         <%= form.hidden_field :survey_id, value: survey.id %>

--- a/app/views/admin/survey/score_range_steps/_list.html.erb
+++ b/app/views/admin/survey/score_range_steps/_list.html.erb
@@ -1,10 +1,10 @@
-<div id="js_survey_score_range_steps_list">
+<div id="js_survey_score_range_steps_list" class="mt-3">
   <% @survey.score_range_steps.each do |step| %>
-    <div class="d-flex justify-content-between border-bottom">
+    <div class="d-flex justify-content-between border-bottom py-2">
       <div><strong><%= step.calculated_range_min_points %>-<%= step.calculated_range_max_points %>: <%= step.name %></strong> - <%= step.description %></div>
       <div>
-        <%= link_to 'Edit', edit_admin_survey_survey_score_range_step_path(@survey, step), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, step) %>
-        <%= link_to "Delete", admin_survey_survey_score_range_step_path(@survey, step), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this score range step?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, step) %>
+        <%= link_to 'Edit', edit_admin_survey_score_range_step_path(@survey, step), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, step) %>
+        <%= link_to "Delete", admin_survey_score_range_step_path(@survey, step), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this score range step?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, step) %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -12,15 +12,15 @@
 <div class="row mb-3">
   <div class="col-7">
     <h2 class="fs-4 text">Questions</h2>
-    <%= link_to 'Add Question Category', new_admin_survey_survey_category_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+    <%#= link_to 'Add Question Category', new_admin_survey_category_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
     <%= tag.div id: "js_survey_question_form", data: {controller: "clearable" } %>
 
-    <%= render partial: "admin/survey/categories/form", locals: {survey: @survey} %>
+    <%#= render partial: "admin/survey/categories/form", locals: {survey: @survey} %>
     
     <% @survey.categories.each do |category| %>
       <h3 class="fs-5 text"><%= category.name %></h3>
       <%= link_to 'Add Question', new_admin_survey_category_survey_question_path(@survey, category), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
-      <%= render partial: "admin/survey/questions/form", locals: {survey: @survey, category: category} %>
+      <%#= render partial: "admin/survey/questions/form", locals: {survey: @survey, category: category} %>
       
       <ul>
         <% category.questions.each do |question| %>
@@ -32,7 +32,7 @@
 
   <div class="col-5">
     <h2 class="fs-4 text">Answer Options</h2>
-    <%= link_to '+ Add', new_admin_survey_survey_answer_option_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+    <%= link_to '+ Add', new_admin_survey_answer_option_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
     <%= tag.div id: "js_survey_answer_option_form", data: {controller: "clearable" } %>
     <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
   </div>
@@ -40,7 +40,7 @@
 
 <h2 class="fs-4 text">Score Interpretation</h2>
 <% if @survey.questions.any? %>
-  <%= link_to '+ Add', new_admin_survey_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+  <%= link_to '+ Add', new_admin_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
   <%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
   <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
       resources :survey_categories, shallow: true do
         resources :survey_questions, shallow: true
       end
-      namespace :survey do
+      scope module: :survey do
         resources :answer_options
         resources :score_range_steps
       end

--- a/spec/requests/admin/survey/answer_options_spec.rb
+++ b/spec/requests/admin/survey/answer_options_spec.rb
@@ -12,27 +12,27 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
 
   describe "unauthenticated access" do
     it "redirects new to sign in" do
-      get new_admin_survey_survey_answer_option_path(survey), headers: turbo_stream_headers
+      get new_admin_survey_answer_option_path(survey), headers: turbo_stream_headers
       expect(response).to redirect_to new_user_session_path
     end
 
     it "redirects create to sign in" do
-      post admin_survey_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Option", value: 1, survey_id: survey.id}}
+      post admin_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Option", value: 1, survey_id: survey.id}}
       expect(response).to redirect_to new_user_session_path
     end
 
     it "redirects edit to sign in" do
-      get edit_admin_survey_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
+      get edit_admin_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
       expect(response).to redirect_to new_user_session_path
     end
 
     it "redirects update to sign in" do
-      patch admin_survey_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated"}}
+      patch admin_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated"}}
       expect(response).to redirect_to new_user_session_path
     end
 
     it "redirects destroy to sign in" do
-      delete admin_survey_survey_answer_option_path(survey, answer_option)
+      delete admin_survey_answer_option_path(survey, answer_option)
       expect(response).to redirect_to new_user_session_path
     end
   end
@@ -43,27 +43,27 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
     before { sign_in(non_admin) }
 
     it "redirects new to root" do
-      get new_admin_survey_survey_answer_option_path(survey), headers: turbo_stream_headers
+      get new_admin_survey_answer_option_path(survey), headers: turbo_stream_headers
       expect(response).to redirect_to root_path
     end
 
     it "redirects create to root" do
-      post admin_survey_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Option", value: 1, survey_id: survey.id}}
+      post admin_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Option", value: 1, survey_id: survey.id}}
       expect(response).to redirect_to root_path
     end
 
     it "redirects edit to root" do
-      get edit_admin_survey_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
+      get edit_admin_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
       expect(response).to redirect_to root_path
     end
 
     it "redirects update to root" do
-      patch admin_survey_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated"}}
+      patch admin_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated"}}
       expect(response).to redirect_to root_path
     end
 
     it "redirects destroy to root" do
-      delete admin_survey_survey_answer_option_path(survey, answer_option)
+      delete admin_survey_answer_option_path(survey, answer_option)
       expect(response).to redirect_to root_path
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
 
     describe "GET new" do
       it "renders successfully" do
-        get new_admin_survey_survey_answer_option_path(survey), headers: turbo_stream_headers
+        get new_admin_survey_answer_option_path(survey), headers: turbo_stream_headers
         expect(response).to be_successful
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
       context "with valid params" do
         it "creates the answer option and redirects to the survey" do
           expect {
-            post admin_survey_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Mild", value: 1, survey_id: survey.id}}
+            post admin_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Mild", value: 1, survey_id: survey.id}}
           }.to change(Survey::AnswerOption, :count).by(1)
 
           expect(response).to redirect_to admin_survey_path(survey)
@@ -92,7 +92,7 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
       context "with invalid params" do
         it "does not create the answer option" do
           expect {
-            post admin_survey_survey_answer_options_path(survey), params: {survey_answer_option: {name: "", value: nil, survey_id: survey.id}}
+            post admin_survey_answer_options_path(survey), params: {survey_answer_option: {name: "", value: nil, survey_id: survey.id}}
           }.not_to change(Survey::AnswerOption, :count)
         end
       end
@@ -100,7 +100,7 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
 
     describe "GET edit" do
       it "renders successfully" do
-        get edit_admin_survey_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
+        get edit_admin_survey_answer_option_path(survey, answer_option), headers: turbo_stream_headers
         expect(response).to be_successful
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
     describe "PATCH update" do
       context "with valid params" do
         it "updates the answer option and redirects to the survey" do
-          patch admin_survey_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated Name"}}
+          patch admin_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated Name"}}
 
           expect(answer_option.reload.name).to eq("Updated Name")
           expect(response).to redirect_to admin_survey_path(survey)
@@ -118,7 +118,7 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
       context "with invalid params" do
         it "does not update the answer option" do
           original_name = answer_option.name
-          patch admin_survey_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: ""}}
+          patch admin_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: ""}}
 
           expect(answer_option.reload.name).to eq(original_name)
         end
@@ -130,7 +130,7 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
         answer_option_to_delete = create(:survey_answer_option, survey: survey)
 
         expect {
-          delete admin_survey_survey_answer_option_path(survey, answer_option_to_delete)
+          delete admin_survey_answer_option_path(survey, answer_option_to_delete)
         }.to change(Survey::AnswerOption, :count).by(-1)
 
         expect(response).to redirect_to admin_survey_path(survey)

--- a/spec/requests/admin/survey/score_range_steps_spec.rb
+++ b/spec/requests/admin/survey/score_range_steps_spec.rb
@@ -20,27 +20,27 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
 
   describe "unauthenticated access" do
     it "redirects new to sign in" do
-      get new_admin_survey_survey_score_range_step_path(survey), headers: turbo_stream_headers
+      get new_admin_survey_score_range_step_path(survey), headers: turbo_stream_headers
       expect(response).to redirect_to new_user_session_path
     end
 
     it "redirects create to sign in" do
-      post admin_survey_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
+      post admin_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
       expect(response).to redirect_to new_user_session_path
     end
 
     it "redirects edit to sign in" do
-      get edit_admin_survey_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
+      get edit_admin_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
       expect(response).to redirect_to new_user_session_path
     end
 
     it "redirects update to sign in" do
-      patch admin_survey_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated"}}
+      patch admin_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated"}}
       expect(response).to redirect_to new_user_session_path
     end
 
     it "redirects destroy to sign in" do
-      delete admin_survey_survey_score_range_step_path(survey, score_range_step)
+      delete admin_survey_score_range_step_path(survey, score_range_step)
       expect(response).to redirect_to new_user_session_path
     end
   end
@@ -51,27 +51,27 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
     before { sign_in(non_admin) }
 
     it "redirects new to root" do
-      get new_admin_survey_survey_score_range_step_path(survey), headers: turbo_stream_headers
+      get new_admin_survey_score_range_step_path(survey), headers: turbo_stream_headers
       expect(response).to redirect_to root_path
     end
 
     it "redirects create to root" do
-      post admin_survey_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
+      post admin_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
       expect(response).to redirect_to root_path
     end
 
     it "redirects edit to root" do
-      get edit_admin_survey_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
+      get edit_admin_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
       expect(response).to redirect_to root_path
     end
 
     it "redirects update to root" do
-      patch admin_survey_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated"}}
+      patch admin_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated"}}
       expect(response).to redirect_to root_path
     end
 
     it "redirects destroy to root" do
-      delete admin_survey_survey_score_range_step_path(survey, score_range_step)
+      delete admin_survey_score_range_step_path(survey, score_range_step)
       expect(response).to redirect_to root_path
     end
   end
@@ -81,7 +81,7 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
 
     describe "GET new" do
       it "renders successfully" do
-        get new_admin_survey_survey_score_range_step_path(survey), headers: turbo_stream_headers
+        get new_admin_survey_score_range_step_path(survey), headers: turbo_stream_headers
         expect(response).to be_successful
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
       context "with valid params" do
         it "creates the score range step and redirects to the survey" do
           expect {
-            post admin_survey_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
+            post admin_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
           }.to change(Survey::ScoreRangeStep, :count).by(1)
 
           expect(response).to redirect_to admin_survey_path(survey)
@@ -100,7 +100,7 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
       context "with invalid params" do
         it "does not create the score range step" do
           expect {
-            post admin_survey_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "", position: nil, survey_id: survey.id}}
+            post admin_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "", position: nil, survey_id: survey.id}}
           }.not_to change(Survey::ScoreRangeStep, :count)
         end
       end
@@ -108,7 +108,7 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
 
     describe "GET edit" do
       it "renders successfully" do
-        get edit_admin_survey_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
+        get edit_admin_survey_score_range_step_path(survey, score_range_step), headers: turbo_stream_headers
         expect(response).to be_successful
       end
     end
@@ -116,7 +116,7 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
     describe "PATCH update" do
       context "with valid params" do
         it "updates the score range step and redirects to the survey" do
-          patch admin_survey_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated Name"}}
+          patch admin_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated Name"}}
 
           expect(score_range_step.reload.name).to eq("Updated Name")
           expect(response).to redirect_to admin_survey_path(survey)
@@ -126,7 +126,7 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
       context "with invalid params" do
         it "does not update the score range step" do
           original_name = score_range_step.name
-          patch admin_survey_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: ""}}
+          patch admin_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: ""}}
 
           expect(score_range_step.reload.name).to eq(original_name)
         end
@@ -138,7 +138,7 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
         step_to_delete = create(:survey_score_range_step, survey: survey)
 
         expect {
-          delete admin_survey_survey_score_range_step_path(survey, step_to_delete)
+          delete admin_survey_score_range_step_path(survey, step_to_delete)
         }.to change(Survey::ScoreRangeStep, :count).by(-1)
 
         expect(response).to redirect_to admin_survey_path(survey)


### PR DESCRIPTION
## Related Issues & PRs
* #1152

## Problems Solved
- makes the routes less cumbersome


## Things Learned
- namespace does three things at once: adds a URL path segment, adds a route name prefix, and scopes the controller directory. 
- Nesting inside resources :surveys only gives you the survey_id parameter — it doesn't suppress any of those three effects. 
- So namespace :survey inside resources :surveys stacks the "survey" URL segment and name prefix on top of the
  "survey" already in the parent resource, giving you admin/surveys/:survey_id/survey/answer_options and admin_survey_survey_answer_option_path. 
- scope module: :survey is the surgical option that applies only the controller namespace change, leaving the URL and route names unaffected.   

## Due Diligence Checks

- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [ ] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
