### PR TITLE
CRUD for admin survey categories and questions

### DIFF
--- a/app/controllers/admin/survey/categories_controller.rb
+++ b/app/controllers/admin/survey/categories_controller.rb
@@ -53,6 +53,7 @@ class Admin::Survey::CategoriesController < AdminController
 
     respond_to do |format|
       if @category.destroy
+        @survey.calculate_score_range_steps_points!
         format.turbo_stream
         format.html { redirect_to admin_survey_path(@survey), notice: "#{@category.name} was successfully destroyed." }
       end

--- a/app/controllers/admin/survey/categories_controller.rb
+++ b/app/controllers/admin/survey/categories_controller.rb
@@ -3,7 +3,7 @@ class Admin::Survey::CategoriesController < AdminController
   before_action :set_survey, only: [:new, :create, :edit, :update, :destroy]
 
   def new
-    @category = @survey.categories.new
+    @category = @survey.categories.new(position: calculated_category_position)
     authorize! @category
 
     respond_to do |format|
@@ -61,6 +61,10 @@ class Admin::Survey::CategoriesController < AdminController
   end
 
   private
+
+  def calculated_category_position
+    @survey.categories.maximum(:position).to_i + 1
+  end
 
   def set_survey
     @survey = Survey.find(params[:survey_id])

--- a/app/controllers/admin/survey/categories_controller.rb
+++ b/app/controllers/admin/survey/categories_controller.rb
@@ -1,0 +1,75 @@
+class Admin::Survey::CategoriesController < AdminController
+  before_action :set_category, only: [:edit, :update, :destroy]
+  before_action :set_survey, only: [:new, :create, :edit, :update, :destroy]
+
+  def new
+    @category = @survey.categories.new
+    authorize! @category
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def create
+    @category = @survey.categories.new(category_params)
+    authorize! @category
+
+    respond_to do |format|
+      if @category.save
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Category was successfully created." }
+      else
+        format.turbo_stream { render :new }
+        format.html { render :new, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def edit
+    authorize! @category
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def update
+    authorize! @category
+
+    respond_to do |format|
+      if @category.update(category_params)
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Category was successfully updated." }
+      else
+        format.turbo_stream { render :edit }
+        format.html { render :edit, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def destroy
+    authorize! @category
+
+    respond_to do |format|
+      if @category.destroy
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "#{@category.name} was successfully destroyed." }
+      end
+    end
+  end
+
+  private
+
+  def set_survey
+    @survey = Survey.find(params[:survey_id])
+  end
+
+  def set_category
+    @category = Survey::Category.find(params[:id])
+  end
+
+  def category_params
+    params.require(:survey_category).permit(:name, :position, :survey_id)
+  end
+end

--- a/app/controllers/admin/survey/questions_controller.rb
+++ b/app/controllers/admin/survey/questions_controller.rb
@@ -6,7 +6,7 @@ class Admin::Survey::QuestionsController < AdminController
   before_action :set_survey, only: [:new, :create, :edit, :update, :destroy]
 
   def new
-    @question = @category.questions.new(position: nil)
+    @question = @category.questions.new(position: calculated_question_position)
     authorize! @question
 
     respond_to do |format|
@@ -68,6 +68,10 @@ class Admin::Survey::QuestionsController < AdminController
   end
 
   private
+
+  def calculated_question_position
+    @category.questions.maximum(:position).to_i + 1
+  end
 
   def set_survey
     @survey = Survey.find(params[:survey_id])

--- a/app/controllers/admin/survey/questions_controller.rb
+++ b/app/controllers/admin/survey/questions_controller.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class Admin::Survey::QuestionsController < AdminController
+  before_action :set_question, only: [:edit, :update, :destroy]
+  before_action :set_category, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_survey, only: [:new, :create, :edit, :update, :destroy]
+
+  def new
+    @question = @category.questions.new(position: nil)
+    authorize! @question
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def create
+    @question = @category.questions.new(question_params)
+    authorize! @question
+
+    respond_to do |format|
+      if @question.save
+        @survey.calculate_score_range_steps_points!
+
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Question was successfully created." }
+      else
+        format.turbo_stream { render :new }
+        format.html { render :new, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def edit
+    authorize! @question
+
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
+  def update
+    authorize! @question
+
+    respond_to do |format|
+      if @question.update(question_params)
+        @survey.calculate_score_range_steps_points!
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Question was successfully updated." }
+      else
+        format.turbo_stream { render :edit }
+        format.html { render :edit, status: :unprocessable_content }
+      end
+    end
+  end
+
+  def destroy
+    authorize! @question
+
+    respond_to do |format|
+      if @question.destroy
+        @survey.calculate_score_range_steps_points!
+
+        format.turbo_stream
+        format.html { redirect_to admin_survey_path(@survey), notice: "Question was successfully destroyed." }
+      end
+    end
+  end
+
+  private
+
+  def set_survey
+    @survey = Survey.find(params[:survey_id])
+  end
+
+  def set_category
+    @category = Survey::Category.find(params[:category_id])
+  end
+
+  def set_question
+    @question = Survey::Question.find(params[:id])
+  end
+
+  def question_params
+    params.require(:survey_question).permit(:text, :position)
+  end
+end

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SurveysHelper
+  def display_score_range_steps?(survey)
+    allowed_to?(:edit?, survey) && survey.questions.any?
+  end
+end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -59,18 +59,19 @@ class Survey < ApplicationRecord
   scope :available_to_public, -> { where(available_to_public: true) }
 
   def max_score
+    return nil if calculated_question_max_points.nil?
     @max_score ||= questions.size * calculated_question_max_points
   end
 
   # TODO: determine when this method should be called and implement that.
   # This should likely be called after any changes to questions, answer options, or score
   # range steps, and should likely also be called as part of a publish action for the survey.
-  def calculate_score_range_steps_points
+  def calculate_score_range_steps_points!
     score_range_steps.update_all(calculated_range_min_points: nil, calculated_range_max_points: nil)
     num_steps = score_range_steps.ordered.size
 
-    raise ArgumentError, "Survey is missing score range steps" if num_steps.zero?
-    raise ArgumentError, "Survey is missing a max score" if max_score.nil?
+    return nil if num_steps.zero?
+    return nil if max_score.nil?
 
     total_positions = max_score - calculated_question_min_points + 1
     base_size = total_positions / num_steps

--- a/app/policies/admin/survey/category_policy.rb
+++ b/app/policies/admin/survey/category_policy.rb
@@ -1,0 +1,21 @@
+class Admin::Survey::CategoryPolicy < ApplicationPolicy
+  def new?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def create?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def edit?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def update?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def destroy?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+end

--- a/app/policies/admin/survey/question_policy.rb
+++ b/app/policies/admin/survey/question_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Admin::Survey::QuestionPolicy < ApplicationPolicy
+  def new?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def create?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def edit?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def update?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+
+  def destroy?
+    allowed_to?(:edit?, record.survey, with: Admin::SurveyPolicy)
+  end
+end

--- a/app/views/admin/survey/answer_options/_list.html.erb
+++ b/app/views/admin/survey/answer_options/_list.html.erb
@@ -1,10 +1,10 @@
 <div id="js_survey_answer_options_list" class="mt-3">
-  <% @survey.answer_options.each do |option| %>
+  <% survey.answer_options.each do |option| %>
     <div class="d-flex justify-content-between border-bottom py-2">
       <div><%= option.value %>: <%= option.name %></div>
       <div>
-        <%= link_to 'Edit', edit_admin_survey_answer_option_path(@survey, option), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, option) %>
-        <%= link_to "Delete", admin_survey_answer_option_path(@survey, option), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer option?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, option) %>
+        <%= link_to 'Edit', edit_admin_survey_answer_option_path(survey, option), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, option) %>
+        <%= link_to "Delete", admin_survey_answer_option_path(survey, option), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer option?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, option) %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/survey/categories/_category.html.erb
+++ b/app/views/admin/survey/categories/_category.html.erb
@@ -1,0 +1,23 @@
+<div id="<%= dom_id(category) %>" class="border-bottom card text-bg-light mb-3">
+  <div class="d-flex justify-content-between align-items-center card-header px-2">
+    <h3 class="fs-6 text mb-0"><%= category.position %>. <%= category.name %></h3>
+    <div>
+      <%= link_to '+ Add Question', new_admin_survey_category_question_path(survey, category), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, survey) %>
+      <%= link_to MaterialIconComponent.new(icon: :settings, title: 'Edit Category').render, edit_admin_survey_category_path(survey, category), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, category) %>
+      <%= link_to MaterialIconComponent.new(icon: :delete, title: 'Delete Category').render, admin_survey_category_path(survey, category), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this category?" }, class: button_class('danger') if allowed_to?(:destroy?, category) %>
+    </div>
+  </div>
+
+  <%= tag.div id: dom_id(category, :js_question_form), data: {controller: "clearable" } %>
+  <div class="card-body">
+    <% category.questions.ordered.each do |question| %>
+      <div class="d-flex justify-content-between py-2">
+        <div><%= question.position %>. <%= question.text %></div>
+        <div>
+          <%= link_to MaterialIconComponent.new(icon: :settings, title: 'Edit Question').render, edit_admin_survey_category_question_path(survey_id: survey.id, category_id: category.id, id: question.id), data: { turbo_stream: true }, class: button_class if allowed_to?(:edit?, question) %>
+          <%= link_to MaterialIconComponent.new(icon: :delete, title: 'Delete Question').render, admin_survey_category_question_path(survey_id: survey.id, category_id: category.id, id: question.id), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this question?" }, class: button_class('danger') if allowed_to?(:destroy?, question) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/survey/categories/_category.html.erb
+++ b/app/views/admin/survey/categories/_category.html.erb
@@ -2,8 +2,8 @@
   <div class="d-flex justify-content-between align-items-center card-header px-2">
     <h3 class="fs-6 text mb-0"><%= category.position %>. <%= category.name %></h3>
     <div>
-      <%= link_to '+ Add Question', new_admin_survey_category_question_path(survey, category), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, survey) %>
-      <%= link_to MaterialIconComponent.new(icon: :settings, title: 'Edit Category').render, edit_admin_survey_category_path(survey, category), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, category) %>
+      <%= link_to '+ Add Question', new_admin_survey_category_question_path(survey, category), data: { turbo_stream: true }, class: button_class('secondary') if allowed_to?(:edit?, survey) %>
+      <%= link_to MaterialIconComponent.new(icon: :edit, title: 'Edit Category').render, edit_admin_survey_category_path(survey, category), data: { turbo_stream: true }, class: button_class('secondary') if allowed_to?(:edit?, category) %>
       <%= link_to MaterialIconComponent.new(icon: :delete, title: 'Delete Category').render, admin_survey_category_path(survey, category), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this category?" }, class: button_class('danger') if allowed_to?(:destroy?, category) %>
     </div>
   </div>
@@ -14,7 +14,7 @@
       <div class="d-flex justify-content-between py-2">
         <div><%= question.position %>. <%= question.text %></div>
         <div>
-          <%= link_to MaterialIconComponent.new(icon: :settings, title: 'Edit Question').render, edit_admin_survey_category_question_path(survey_id: survey.id, category_id: category.id, id: question.id), data: { turbo_stream: true }, class: button_class if allowed_to?(:edit?, question) %>
+          <%= link_to MaterialIconComponent.new(icon: :edit, title: 'Edit Question').render, edit_admin_survey_category_question_path(survey_id: survey.id, category_id: category.id, id: question.id), data: { turbo_stream: true }, class: button_class('secondary') if allowed_to?(:edit?, question) %>
           <%= link_to MaterialIconComponent.new(icon: :delete, title: 'Delete Question').render, admin_survey_category_question_path(survey_id: survey.id, category_id: category.id, id: question.id), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this question?" }, class: button_class('danger') if allowed_to?(:destroy?, question) %>
         </div>
       </div>

--- a/app/views/admin/survey/categories/_form.html.erb
+++ b/app/views/admin/survey/categories/_form.html.erb
@@ -1,0 +1,32 @@
+<div class="container">
+  <div class="row border-top border-bottom mb-3">
+    <div class="col p-2 border-end border-start bg-light">  
+      <%= form_with model: [:admin, category], html: { novalidate: true } do |form| %>
+        
+        <%= render 'shared/errors', object: category %>
+        <%= form.hidden_field :survey_id, value: survey.id %>
+
+        <div class="row">
+          <div class="col-3">
+            <div class="mb-3">
+              <%= form.label :position, class: "required" %>
+              <%= form.number_field :position, required: true, class: 'form-control' %>
+            </div>
+          </div>
+          <div class="col-9">
+            <div class="mb-3">
+              <%= form.label :name, class: "required" %>
+              <%= form.text_field :name, required: true, class: 'form-control' %>
+            </div>
+          </div>
+        </div>
+
+        <div class="actions d-flex justify-content-end align-items-start gap-2">
+          <%= button_tag "Cancel", type: "button", data: { action: "clearable#clear" }, class: button_class('secondary') %>
+          <%= form.submit "Submit", class: button_class('success') %>      
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/admin/survey/categories/_list.html.erb
+++ b/app/views/admin/survey/categories/_list.html.erb
@@ -1,0 +1,29 @@
+<div id="js_survey_categories_list">
+  <% survey.categories.each do |category| %>
+    <div class="border-bottom py-2">
+      <div class="d-flex justify-content-between">
+        <h3 class="fs-6 text"><%= category.name %></h3>
+        <div>
+          <%= link_to '+ Add Question', new_admin_survey_category_question_path(survey, category), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, survey) %>
+          <%= link_to 'Edit', edit_admin_survey_category_path(survey, category), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, category) %>
+          <%= link_to "Delete", admin_survey_category_path(survey, category), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer category?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, category) %>
+        </div>
+      </div>
+
+      <%= tag.div id: dom_id(category, :js_question_form), data: {controller: "clearable" } %>
+      
+      <% category.questions.each do |question| %>
+        <div class="d-flex justify-content-between border-bottom py-2">
+          <div><%= question.position %>: <%= question.text %></div>
+          <div>
+            <%= link_to 'Edit', edit_admin_survey_category_question_path(survey, question), data: { turbo_stream: true }, class: button_class if allowed_to?(:edit?, question) %>
+            <%= link_to "Delete", admin_survey_category_question_path(survey, question), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer question?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, option) %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+
+

--- a/app/views/admin/survey/categories/_list.html.erb
+++ b/app/views/admin/survey/categories/_list.html.erb
@@ -1,27 +1,6 @@
 <div id="js_survey_categories_list">
   <% survey.categories.each do |category| %>
-    <div class="border-bottom py-2">
-      <div class="d-flex justify-content-between">
-        <h3 class="fs-6 text"><%= category.name %></h3>
-        <div>
-          <%= link_to '+ Add Question', new_admin_survey_category_question_path(survey, category), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, survey) %>
-          <%= link_to 'Edit', edit_admin_survey_category_path(survey, category), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, category) %>
-          <%= link_to "Delete", admin_survey_category_path(survey, category), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer category?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, category) %>
-        </div>
-      </div>
-
-      <%= tag.div id: dom_id(category, :js_question_form), data: {controller: "clearable" } %>
-      
-      <% category.questions.each do |question| %>
-        <div class="d-flex justify-content-between border-bottom py-2">
-          <div><%= question.position %>: <%= question.text %></div>
-          <div>
-            <%= link_to 'Edit', edit_admin_survey_category_question_path(survey, question), data: { turbo_stream: true }, class: button_class if allowed_to?(:edit?, question) %>
-            <%= link_to "Delete", admin_survey_category_question_path(survey, question), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer question?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, option) %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <%= render partial: "admin/survey/categories/category", locals: {survey: survey, category: category} %>
   <% end %>
 </div>
 

--- a/app/views/admin/survey/categories/create.turbo_stream.erb
+++ b/app/views/admin/survey/categories/create.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_category_form", "" %>
+
+<%= turbo_stream.replace "js_survey_categories_list" do %>
+  <%= render partial: 'admin/survey/categories/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/categories/destroy.turbo_stream.erb
+++ b/app/views/admin/survey/categories/destroy.turbo_stream.erb
@@ -3,3 +3,7 @@
 <%= turbo_stream.replace "js_survey_categories_list" do %>
   <%= render partial: 'admin/survey/categories/list', locals: {survey: @survey} %>
 <% end %>
+
+<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
+  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/categories/destroy.turbo_stream.erb
+++ b/app/views/admin/survey/categories/destroy.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_category_form", "" %>
+
+<%= turbo_stream.replace "js_survey_categories_list" do %>
+  <%= render partial: 'admin/survey/categories/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/categories/edit.turbo_stream.erb
+++ b/app/views/admin/survey/categories/edit.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "js_survey_category_form" do %>
+  <%= render partial: "admin/survey/categories/form", locals: {survey: @survey, category: @category} %>
+<% end %>

--- a/app/views/admin/survey/categories/new.turbo_stream.erb
+++ b/app/views/admin/survey/categories/new.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "js_survey_category_form" do %>
+  <%= render partial: "admin/survey/categories/form", locals: {survey: @survey, category: @category} %>
+<% end %>

--- a/app/views/admin/survey/categories/update.turbo_stream.erb
+++ b/app/views/admin/survey/categories/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "js_survey_category_form", "" %>
+
+<%= turbo_stream.replace "js_survey_categories_list" do %>
+  <%= render partial: 'admin/survey/categories/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/questions/_form.html.erb
+++ b/app/views/admin/survey/questions/_form.html.erb
@@ -1,0 +1,1 @@
+question form

--- a/app/views/admin/survey/questions/_form.html.erb
+++ b/app/views/admin/survey/questions/_form.html.erb
@@ -1,1 +1,30 @@
-question form
+<div class="container">
+  <div class="row border-top border-bottom mb-3">
+    <div class="col p-2 border-end border-start bg-light">  
+      <%= form_with model: question, url: url, html: { novalidate: true } do |form| %>
+
+        <%= render 'shared/errors', object: question %>
+
+        <div class="row">
+          <div class="col-3">
+            <div class="mb-3">
+              <%= form.label :position, class: "required" %>
+              <%= form.number_field :position, required: true, class: 'form-control' %>
+            </div>
+          </div>
+          <div class="col-9">
+            <div class="mb-3">
+              <%= form.label :text, class: "required" %>
+              <%= form.text_area :text, required: true, class: 'form-control' %>
+            </div>
+          </div>
+        </div>
+
+        <div class="actions d-flex justify-content-end align-items-start gap-2">
+          <%= button_tag "Cancel", type: "button", data: { action: "clearable#clear" }, class: button_class('secondary') %>
+          <%= form.submit "Submit", class: button_class('success') %>      
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/survey/questions/create.turbo_stream.erb
+++ b/app/views/admin/survey/questions/create.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.update dom_id(@category, :js_question_form), "" %>
+
+<%= turbo_stream.replace dom_id(@category) do %>
+  <%= render partial: 'admin/survey/categories/category', locals: {survey: @survey, category: @category} %>
+<% end %>
+
+<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
+  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/questions/destroy.turbo_stream.erb
+++ b/app/views/admin/survey/questions/destroy.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.update dom_id(@category, :js_question_form), "" %>
+
+<%= turbo_stream.replace dom_id(@category) do %>
+  <%= render partial: 'admin/survey/categories/category', locals: {survey: @survey, category: @category} %>
+<% end %>
+
+<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
+  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/questions/edit.turbo_stream.erb
+++ b/app/views/admin/survey/questions/edit.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update dom_id(@category, :js_question_form) do %>
+  <%= render partial: "admin/survey/questions/form", locals: {survey: @survey, category: @category, question: @question, url: admin_survey_category_question_path(@survey, @category, @question)} %>
+<% end %>

--- a/app/views/admin/survey/questions/new.turbo_stream.erb
+++ b/app/views/admin/survey/questions/new.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update dom_id(@category, :js_question_form) do %>
+  <%= render partial: "admin/survey/questions/form", locals: {survey: @survey, category: @category, question: @question, url: admin_survey_category_questions_path(@survey, @category)} %>
+<% end %>

--- a/app/views/admin/survey/questions/update.turbo_stream.erb
+++ b/app/views/admin/survey/questions/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.update dom_id(@category, :js_question_form), "" %>
+
+<%= turbo_stream.replace dom_id(@category) do %>
+  <%= render partial: 'admin/survey/categories/category', locals: {survey: @survey, category: @category} %>
+<% end %>
+
+<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
+  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/score_range_steps/_list.html.erb
+++ b/app/views/admin/survey/score_range_steps/_list.html.erb
@@ -1,10 +1,10 @@
 <div id="js_survey_score_range_steps_list" class="mt-3">
-  <% @survey.score_range_steps.each do |step| %>
+  <% survey.score_range_steps.each do |step| %>
     <div class="d-flex justify-content-between border-bottom py-2">
       <div><strong><%= step.calculated_range_min_points %>-<%= step.calculated_range_max_points %>: <%= step.name %></strong> - <%= step.description %></div>
       <div>
-        <%= link_to 'Edit', edit_admin_survey_score_range_step_path(@survey, step), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, step) %>
-        <%= link_to "Delete", admin_survey_score_range_step_path(@survey, step), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this score range step?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, step) %>
+        <%= link_to 'Edit', edit_admin_survey_score_range_step_path(survey, step), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, step) %>
+        <%= link_to "Delete", admin_survey_score_range_step_path(survey, step), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this score range step?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, step) %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -3,7 +3,7 @@
 <div class="d-flex justify-content-between">
   <h1><%= @survey.name.titleize %> <span class="fs-6 text">(<%= @survey.status %>)</span></h1>
   <div class="d-flex justify-content-end align-items-start gap-1">
-    <%= link_to 'Back to Surveys', admin_surveys_path, class: button_class('secondary') %>
+    <%= link_to '← Back to Surveys', admin_surveys_path, class: button_class('secondary') %>
     <%= render partial: "action_buttons", locals: {survey: @survey} %>
   </div>
 </div>
@@ -13,7 +13,7 @@
   <div class="col-12 col-md-7">
     <div class="d-flex justify-content-between align-items-start">
       <h2 class="fs-4 text">Questions</h2>
-      <%= link_to '+ Add Category', new_admin_survey_category_path(@survey), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, @survey) %>
+      <%= link_to '+ Add Category', new_admin_survey_category_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
     </div>
     <%= tag.div id: "js_survey_category_form", data: {controller: "clearable" } %>
     <%= render partial: 'admin/survey/categories/list', locals: {survey: @survey} %>
@@ -22,7 +22,7 @@
   <div class="col-12 col-md-5">
     <div class="d-flex justify-content-between align-items-start">
       <h2 class="fs-4 text">Answer Options</h2>
-      <%= link_to '+ Add', new_admin_survey_answer_option_path(@survey), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, @survey) %>
+      <%= link_to '+ Add Option', new_admin_survey_answer_option_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
     </div>
     <%= tag.div id: "js_survey_answer_option_form", data: {controller: "clearable" } %>
     <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
@@ -31,7 +31,7 @@
 
 <div class="d-flex justify-content-between align-items-start">
   <h2 class="fs-4 text">Score Interpretation</h2>
-  <%= link_to '+ Add', new_admin_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('success') if display_score_range_steps?(@survey) %>
+  <%= link_to '+ Add Step', new_admin_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if display_score_range_steps?(@survey) %>
 </div>
 <% if display_score_range_steps?(@survey) %>
   <%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -10,17 +10,16 @@
 <p><%= @survey.description %></p> 
 
 <div class="row mb-3">
-  <div class="col-7">
+  <div class="col-12 col-md-7">
     <div class="d-flex justify-content-between align-items-start">
       <h2 class="fs-4 text">Questions</h2>
       <%= link_to '+ Add Category', new_admin_survey_category_path(@survey), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, @survey) %>
     </div>
     <%= tag.div id: "js_survey_category_form", data: {controller: "clearable" } %>
-
     <%= render partial: 'admin/survey/categories/list', locals: {survey: @survey} %>
   </div>
 
-  <div class="col-5">
+  <div class="col-12 col-md-5">
     <div class="d-flex justify-content-between align-items-start">
       <h2 class="fs-4 text">Answer Options</h2>
       <%= link_to '+ Add', new_admin_survey_answer_option_path(@survey), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, @survey) %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -31,9 +31,9 @@
 
 <div class="d-flex justify-content-between align-items-start">
   <h2 class="fs-4 text">Score Interpretation</h2>
-  <%= link_to '+ Add', new_admin_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:new?, @survey.score_range_steps.new) %>
+  <%= link_to '+ Add', new_admin_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('success') if display_score_range_steps?(@survey) %>
 </div>
-<% if allowed_to?(:new?, @survey.score_range_steps.new) %>
+<% if display_score_range_steps?(@survey) %>
   <%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
   <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
 <% else %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -11,36 +11,30 @@
 
 <div class="row mb-3">
   <div class="col-7">
-    <h2 class="fs-4 text">Questions</h2>
-    <%#= link_to 'Add Question Category', new_admin_survey_category_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
-    <%= tag.div id: "js_survey_question_form", data: {controller: "clearable" } %>
+    <div class="d-flex justify-content-between align-items-start">
+      <h2 class="fs-4 text">Questions</h2>
+      <%= link_to '+ Add Category', new_admin_survey_category_path(@survey), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, @survey) %>
+    </div>
+    <%= tag.div id: "js_survey_category_form", data: {controller: "clearable" } %>
 
-    <%#= render partial: "admin/survey/categories/form", locals: {survey: @survey} %>
-    
-    <% @survey.categories.each do |category| %>
-      <h3 class="fs-5 text"><%= category.name %></h3>
-      <%= link_to 'Add Question', new_admin_survey_category_survey_question_path(@survey, category), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
-      <%#= render partial: "admin/survey/questions/form", locals: {survey: @survey, category: category} %>
-      
-      <ul>
-        <% category.questions.each do |question| %>
-          <li><%= question.position %>: <%= question.text %></li>
-        <% end %>
-      </ul>
-    <% end %>
+    <%= render partial: 'admin/survey/categories/list', locals: {survey: @survey} %>
   </div>
 
   <div class="col-5">
-    <h2 class="fs-4 text">Answer Options</h2>
-    <%= link_to '+ Add', new_admin_survey_answer_option_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+    <div class="d-flex justify-content-between align-items-start">
+      <h2 class="fs-4 text">Answer Options</h2>
+      <%= link_to '+ Add', new_admin_survey_answer_option_path(@survey), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:edit?, @survey) %>
+    </div>
     <%= tag.div id: "js_survey_answer_option_form", data: {controller: "clearable" } %>
     <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
   </div>
 </div>
 
-<h2 class="fs-4 text">Score Interpretation</h2>
-<% if @survey.questions.any? %>
-  <%= link_to '+ Add', new_admin_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, @survey) %>
+<div class="d-flex justify-content-between align-items-start">
+  <h2 class="fs-4 text">Score Interpretation</h2>
+  <%= link_to '+ Add', new_admin_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('success') if allowed_to?(:new?, @survey.score_range_steps.new) %>
+</div>
+<% if allowed_to?(:new?, @survey.score_range_steps.new) %>
   <%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
   <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
 <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,10 +17,10 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users, only: [:index, :show]
     resources :surveys, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
-      resources :survey_categories, shallow: true do
-        resources :survey_questions, shallow: true
-      end
       scope module: :survey do
+        resources :categories do
+          resources :questions
+        end
         resources :answer_options
         resources :score_range_steps
       end

--- a/lib/tasks/seed/surveys.rake
+++ b/lib/tasks/seed/surveys.rake
@@ -91,7 +91,7 @@ namespace :db do
       survey.score_range_steps.create!(name: "Severe Depression", position: 5, description: "Your responses indicate that you are experiencing severe symptoms of depression.")
       survey.score_range_steps.create!(name: "Extreme Depression", position: 6, description: "Your responses indicate that you are experiencing extreme symptoms of depression.")
 
-      survey.calculate_score_range_steps_points
+      survey.calculate_score_range_steps_points!
       puts "Finished seeding surveys."
     end
 

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Survey, type: :model do
     end
   end
 
-  describe "calculate_score_range_steps_points" do
+  describe "calculate_score_range_steps_points!" do
     let(:survey) { create(:survey) }
     let(:survey_category) { create(:survey_category, survey: survey) }
 
@@ -108,7 +108,7 @@ RSpec.describe Survey, type: :model do
 
       # Call the method under test
       survey.reload
-      survey.calculate_score_range_steps_points
+      survey.calculate_score_range_steps_points!
 
       expect(survey.score_range_steps.first.calculated_range_min_points).to eq(0)
       expect(survey.score_range_steps.first.calculated_range_max_points).to eq(6)
@@ -120,12 +120,19 @@ RSpec.describe Survey, type: :model do
       expect(survey.score_range_steps.third.calculated_range_max_points).to eq(20)
     end
 
-    it "raises an error if there are no score range steps" do
+    it "returns nil if there are no score range steps" do
       5.times { |v| create(:survey_answer_option, survey: survey, value: v, name: "Option #{v}") } # Creates values 0-4
       create_list(:survey_question, 5, category: survey_category) # 5 questions * max 4 points each = max score of 20 for the survey
 
       survey.score_range_steps.destroy_all
-      expect { survey.calculate_score_range_steps_points }.to raise_error(ArgumentError, "Survey is missing score range steps")
+      expect(survey.calculate_score_range_steps_points!).to be_nil
+    end
+
+    it "returns nil if there the survey has no max score" do
+      5.times { |v| create(:survey_answer_option, survey: survey, value: v, name: "Option #{v}") } # Creates values 0-4
+      create_list(:survey_question, 5, category: survey_category) # 5 questions * max 4 points each = max score of 20 for the survey
+      allow(survey).to receive(:max_score).and_return(nil)
+      expect(survey.calculate_score_range_steps_points!).to be_nil
     end
 
     context "when the available points for the survey is not evenly divisible by the number of score range steps" do
@@ -143,7 +150,7 @@ RSpec.describe Survey, type: :model do
       end
 
       it "divides the remainder amongst the first few range steps" do
-        survey.calculate_score_range_steps_points
+        survey.calculate_score_range_steps_points!
 
         first_step_distance = (survey.score_range_steps.first.calculated_range_min_points..survey.score_range_steps.first.calculated_range_max_points).to_a.length
         expect(first_step_distance).to eq(6) # 5 base points + 1 extra point from the remainder
@@ -156,14 +163,14 @@ RSpec.describe Survey, type: :model do
       end
 
       it "ensures the survey_max_score is the calculated_range_max_points for the last score range step" do
-        survey.calculate_score_range_steps_points
+        survey.calculate_score_range_steps_points!
         survey.reload
         expect(survey.score_range_steps.last.calculated_range_max_points).to eq(survey.max_score)
       end
 
       it "assigns min and max points to each of the survey's score_range_steps" do
         survey.reload
-        survey.calculate_score_range_steps_points
+        survey.calculate_score_range_steps_points!
 
         expect(survey.score_range_steps[0].calculated_range_min_points).to eq(0)
         expect(survey.score_range_steps[0].calculated_range_max_points).to eq(5)

--- a/spec/policies/admin/survey/category_policy_spec.rb
+++ b/spec/policies/admin/survey/category_policy_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Survey::CategoryPolicy, type: :policy do
+  let(:admin_user) { build_stubbed(:user, admin: true) }
+  let(:other_user) { build_stubbed(:user, admin: false) }
+  let(:policy) { described_class.new(record, user: current_user) }
+
+  # All rules delegate to Admin::SurveyPolicy#edit?, so we only need to verify
+  # the delegation is wired up correctly — not re-test all survey policy combinations.
+
+  context "when Admin::SurveyPolicy permits edit (admin who owns a draft survey)" do
+    let(:current_user) { admin_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+    let(:record) { build_stubbed(:survey_category, survey: survey) }
+
+    it "permits new?" do
+      expect(policy.apply(:new?)).to eq(true)
+    end
+
+    it "permits create?" do
+      expect(policy.apply(:create?)).to eq(true)
+    end
+
+    it "permits edit?" do
+      expect(policy.apply(:edit?)).to eq(true)
+    end
+
+    it "permits update?" do
+      expect(policy.apply(:update?)).to eq(true)
+    end
+
+    it "permits destroy?" do
+      expect(policy.apply(:destroy?)).to eq(true)
+    end
+  end
+
+  context "when Admin::SurveyPolicy denies edit (non-admin user)" do
+    let(:current_user) { other_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+    let(:record) { build_stubbed(:survey_category, survey: survey) }
+
+    it "denies new?" do
+      expect(policy.apply(:new?)).to eq(false)
+    end
+
+    it "denies create?" do
+      expect(policy.apply(:create?)).to eq(false)
+    end
+
+    it "denies edit?" do
+      expect(policy.apply(:edit?)).to eq(false)
+    end
+
+    it "denies update?" do
+      expect(policy.apply(:update?)).to eq(false)
+    end
+
+    it "denies destroy?" do
+      expect(policy.apply(:destroy?)).to eq(false)
+    end
+  end
+end

--- a/spec/policies/admin/survey/question_policy_spec.rb
+++ b/spec/policies/admin/survey/question_policy_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::Survey::QuestionPolicy, type: :policy do
+  let(:admin_user) { build_stubbed(:user, admin: true) }
+  let(:other_user) { build_stubbed(:user, admin: false) }
+  let(:policy) { described_class.new(record, user: current_user) }
+
+  # All rules delegate to Admin::SurveyPolicy#edit? via record.category.survey,
+  # so we only need to verify the delegation is wired up correctly.
+
+  context "when Admin::SurveyPolicy permits edit (admin who owns a draft survey)" do
+    let(:current_user) { admin_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: false, user_id: admin_user.id) }
+    let(:category) { build_stubbed(:survey_category, survey: survey) }
+    let(:record) { build_stubbed(:survey_question, category: category) }
+
+    it "permits new?" do
+      expect(policy.apply(:new?)).to eq(true)
+    end
+
+    it "permits create?" do
+      expect(policy.apply(:create?)).to eq(true)
+    end
+
+    it "permits edit?" do
+      expect(policy.apply(:edit?)).to eq(true)
+    end
+
+    it "permits update?" do
+      expect(policy.apply(:update?)).to eq(true)
+    end
+
+    it "permits destroy?" do
+      expect(policy.apply(:destroy?)).to eq(true)
+    end
+  end
+
+  context "when Admin::SurveyPolicy denies edit (non-admin user)" do
+    let(:current_user) { other_user }
+    let(:survey) { build_stubbed(:survey, status: :draft, available_to_public: true, user_id: other_user.id) }
+    let(:category) { build_stubbed(:survey_category, survey: survey) }
+    let(:record) { build_stubbed(:survey_question, category: category) }
+
+    it "denies new?" do
+      expect(policy.apply(:new?)).to eq(false)
+    end
+
+    it "denies create?" do
+      expect(policy.apply(:create?)).to eq(false)
+    end
+
+    it "denies edit?" do
+      expect(policy.apply(:edit?)).to eq(false)
+    end
+
+    it "denies update?" do
+      expect(policy.apply(:update?)).to eq(false)
+    end
+
+    it "denies destroy?" do
+      expect(policy.apply(:destroy?)).to eq(false)
+    end
+  end
+end

--- a/spec/requests/admin/survey/categories_spec.rb
+++ b/spec/requests/admin/survey/categories_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Survey::Categories", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:survey) { create(:survey, status: :draft, user_id: admin.id) }
+  let(:category) { create(:survey_category, survey: survey) }
+
+  # new and edit only respond to turbo_stream, so requests must include the Accept header
+  let(:turbo_stream_headers) { {"Accept" => "text/vnd.turbo-stream.html"} }
+
+  describe "unauthenticated access" do
+    it "redirects new to sign in" do
+      get new_admin_survey_category_path(survey), headers: turbo_stream_headers
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects create to sign in" do
+      post admin_survey_categories_path(survey), params: {survey_category: {name: "Feelings", position: 0, survey_id: survey.id}}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects edit to sign in" do
+      get edit_admin_survey_category_path(survey, category), headers: turbo_stream_headers
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects update to sign in" do
+      patch admin_survey_category_path(survey, category), params: {survey_category: {name: "Updated"}}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects destroy to sign in" do
+      delete admin_survey_category_path(survey, category)
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  describe "non-admin access" do
+    let(:non_admin) { create(:user, admin: false) }
+
+    before { sign_in(non_admin) }
+
+    it "redirects new to root" do
+      get new_admin_survey_category_path(survey), headers: turbo_stream_headers
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects create to root" do
+      post admin_survey_categories_path(survey), params: {survey_category: {name: "Feelings", position: 0, survey_id: survey.id}}
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects edit to root" do
+      get edit_admin_survey_category_path(survey, category), headers: turbo_stream_headers
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects update to root" do
+      patch admin_survey_category_path(survey, category), params: {survey_category: {name: "Updated"}}
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects destroy to root" do
+      delete admin_survey_category_path(survey, category)
+      expect(response).to redirect_to root_path
+    end
+  end
+
+  describe "admin access" do
+    before { sign_in(admin) }
+
+    describe "GET new" do
+      it "renders successfully" do
+        get new_admin_survey_category_path(survey), headers: turbo_stream_headers
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST create" do
+      context "with valid params" do
+        it "creates the category and redirects to the survey" do
+          expect {
+            post admin_survey_categories_path(survey), params: {survey_category: {name: "Feelings", position: 0, survey_id: survey.id}}
+          }.to change(Survey::Category, :count).by(1)
+
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not create the category" do
+          expect {
+            post admin_survey_categories_path(survey), params: {survey_category: {name: "", position: 0, survey_id: survey.id}}
+          }.not_to change(Survey::Category, :count)
+        end
+      end
+    end
+
+    describe "GET edit" do
+      it "renders successfully" do
+        get edit_admin_survey_category_path(survey, category), headers: turbo_stream_headers
+        expect(response).to be_successful
+      end
+    end
+
+    describe "PATCH update" do
+      context "with valid params" do
+        it "updates the category and redirects to the survey" do
+          patch admin_survey_category_path(survey, category), params: {survey_category: {name: "Updated Name"}}
+
+          expect(category.reload.name).to eq("Updated Name")
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not update the category" do
+          original_name = category.name
+          patch admin_survey_category_path(survey, category), params: {survey_category: {name: ""}}
+
+          expect(category.reload.name).to eq(original_name)
+        end
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "destroys the category and redirects to the survey" do
+        category_to_delete = create(:survey_category, survey: survey)
+
+        expect {
+          delete admin_survey_category_path(survey, category_to_delete)
+        }.to change(Survey::Category, :count).by(-1)
+
+        expect(response).to redirect_to admin_survey_path(survey)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/survey/questions_spec.rb
+++ b/spec/requests/admin/survey/questions_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin::Survey::Questions", type: :request do
+  let(:admin) { create(:user, admin: true) }
+  let(:survey) { create(:survey, status: :draft, user_id: admin.id) }
+  let(:category) { create(:survey_category, survey: survey) }
+  let(:question) { create(:survey_question, category: category) }
+
+  # new and edit only respond to turbo_stream, so requests must include the Accept header
+  let(:turbo_stream_headers) { {"Accept" => "text/vnd.turbo-stream.html"} }
+
+  describe "unauthenticated access" do
+    it "redirects new to sign in" do
+      get new_admin_survey_category_question_path(survey, category), headers: turbo_stream_headers
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects create to sign in" do
+      post admin_survey_category_questions_path(survey, category), params: {survey_question: {text: "How often do you feel hopeless?", position: 0}}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects edit to sign in" do
+      get edit_admin_survey_category_question_path(survey, category, question), headers: turbo_stream_headers
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects update to sign in" do
+      patch admin_survey_category_question_path(survey, category, question), params: {survey_question: {text: "Updated text"}}
+      expect(response).to redirect_to new_user_session_path
+    end
+
+    it "redirects destroy to sign in" do
+      delete admin_survey_category_question_path(survey, category, question)
+      expect(response).to redirect_to new_user_session_path
+    end
+  end
+
+  describe "non-admin access" do
+    let(:non_admin) { create(:user, admin: false) }
+
+    before { sign_in(non_admin) }
+
+    it "redirects new to root" do
+      get new_admin_survey_category_question_path(survey, category), headers: turbo_stream_headers
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects create to root" do
+      post admin_survey_category_questions_path(survey, category), params: {survey_question: {text: "How often do you feel hopeless?", position: 0}}
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects edit to root" do
+      get edit_admin_survey_category_question_path(survey, category, question), headers: turbo_stream_headers
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects update to root" do
+      patch admin_survey_category_question_path(survey, category, question), params: {survey_question: {text: "Updated text"}}
+      expect(response).to redirect_to root_path
+    end
+
+    it "redirects destroy to root" do
+      delete admin_survey_category_question_path(survey, category, question)
+      expect(response).to redirect_to root_path
+    end
+  end
+
+  describe "admin access" do
+    before { sign_in(admin) }
+
+    describe "GET new" do
+      it "renders successfully" do
+        get new_admin_survey_category_question_path(survey, category), headers: turbo_stream_headers
+        expect(response).to be_successful
+      end
+    end
+
+    describe "POST create" do
+      context "with valid params" do
+        it "creates the question and redirects to the survey" do
+          expect {
+            post admin_survey_category_questions_path(survey, category), params: {survey_question: {text: "How often do you feel hopeless?", position: 0}}
+          }.to change(Survey::Question, :count).by(1)
+
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not create the question" do
+          expect {
+            post admin_survey_category_questions_path(survey, category), params: {survey_question: {text: "", position: 0}}
+          }.not_to change(Survey::Question, :count)
+        end
+      end
+    end
+
+    describe "GET edit" do
+      it "renders successfully" do
+        get edit_admin_survey_category_question_path(survey, category, question), headers: turbo_stream_headers
+        expect(response).to be_successful
+      end
+    end
+
+    describe "PATCH update" do
+      context "with valid params" do
+        it "updates the question and redirects to the survey" do
+          patch admin_survey_category_question_path(survey, category, question), params: {survey_question: {text: "Updated text"}}
+
+          expect(question.reload.text).to eq("Updated text")
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
+      end
+
+      context "with invalid params" do
+        it "does not update the question" do
+          original_text = question.text
+          patch admin_survey_category_question_path(survey, category, question), params: {survey_question: {text: ""}}
+
+          expect(question.reload.text).to eq(original_text)
+        end
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "destroys the question and redirects to the survey" do
+        question_to_delete = create(:survey_question, category: category)
+
+        expect {
+          delete admin_survey_category_question_path(survey, category, question_to_delete)
+        }.to change(Survey::Question, :count).by(-1)
+
+        expect(response).to redirect_to admin_survey_path(survey)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Related Issues & PRs
* Closes #1177 
* Closes #1152 
* Closes #1153

## This PR
- gives admins the ability to add/edit categories and questions within those categories for surveys
- updates the score range calculations every time a question is added/removed from the survey and any time a category is deleted
- uncovers a couple of issues that need to be handled next: #1186 and #1187

## Screenshots
Adding a category and editing it
<img width="1260" height="809" alt="add_category" src="https://github.com/user-attachments/assets/efd976d2-f604-4907-9619-5dd1e1e0f4ab" />

Adding questions to categories
<img width="1260" height="809" alt="add_question" src="https://github.com/user-attachments/assets/216a8e06-371f-4cd0-bc6e-36d819a883b8" />

Removing a category, it's questions, and seeing the score range calculations
<img width="1260" height="828" alt="delete_category" src="https://github.com/user-attachments/assets/ea13a9c9-3ff8-4765-816c-0180c1093bb0" />


## Things Learned
- When you break from rails routing conventions ever so slightly -- still using rails tools -- you lose some of that magic form url interpretation. Since I am using a scope module to get access to the `Admin::` namspace in the controllers, I renamed the routes from `survey_categories` to `categories` (etc) and while that give you much nicer path helpers, it breaks the `form_with`'s default interpretation. It was easy to solve by passing the url to the form from the `new` and `edit` views, but it was an annoying tradeoff. 
- Namespacing has annoying tradeoffs everywhere. But I still think it is worth it for the mental overhead saved in naming conventions. 
- I decided against doing shallow routes for categories and questions. It seems like a sus decision, but this is Claude's recap for my decision-making process:
  - Form URL inference breaks. With shallow routes, member actions (edit, update, destroy) drop the parent IDs from the URL. That means form_with for edit needs to post to /admin/categories/:id (no survey or category in the path), but we were already fighting the model-name inference problem. Shallow routing adds another layer of inconsistency to manage.
  - Controllers lose parent context in params. With shallow member routes, params[:survey_id] and params[:category_id] aren't present for edit, update, and destroy. The controller's set_survey and set_category  
  before-actions rely on those params. You'd have to load the survey by going through the record's association instead (@question.category.survey), which works but is an extra query and inconsistent with how the other actions work.
  - The tradeoff we accepted is slightly longer URLs (/admin/surveys/:survey_id/categories/:category_id/questions/:id) in exchange for consistent, predictable params in every action and no special-casing in controllers or forms.

## Due Diligence Checks

- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
- [x] revisit shallow routes reasoning
- [x] revisit answer_options list issues
