### PR TITLE
Admin Survey: Convert link text to icons

### DIFF
--- a/app/views/admin/survey/answer_options/_list.html.erb
+++ b/app/views/admin/survey/answer_options/_list.html.erb
@@ -1,10 +1,10 @@
 <div id="js_survey_answer_options_list" class="mt-3">
   <% survey.answer_options.each do |option| %>
     <div class="d-flex justify-content-between border-bottom py-2">
-      <div><%= option.value %>: <%= option.name %></div>
-      <div>
-        <%= link_to 'Edit', edit_admin_survey_answer_option_path(survey, option), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, option) %>
-        <%= link_to "Delete", admin_survey_answer_option_path(survey, option), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer option?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, option) %>
+      <div class="me-3"><%= option.value %>: <%= option.name %></div>
+      <div class="flex-shrink-0">
+        <%= link_to MaterialIconComponent.new(icon: :edit, title: 'Edit Option').render, edit_admin_survey_answer_option_path(survey, option), data: { turbo_stream: true }, class: button_class('secondary') if allowed_to?(:edit?, option) %>
+        <%= link_to MaterialIconComponent.new(icon: :delete, title: 'Delete Option').render, admin_survey_answer_option_path(survey, option), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this answer option?" }, class: button_class('danger') if allowed_to?(:destroy?, option) %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/survey/categories/_category.html.erb
+++ b/app/views/admin/survey/categories/_category.html.erb
@@ -12,8 +12,8 @@
   <div class="card-body">
     <% category.questions.ordered.each do |question| %>
       <div class="d-flex justify-content-between py-2">
-        <div><%= question.position %>. <%= question.text %></div>
-        <div>
+        <div class="me-3"><%= question.position %>. <%= question.text %></div>
+        <div class="flex-shrink-0">
           <%= link_to MaterialIconComponent.new(icon: :edit, title: 'Edit Question').render, edit_admin_survey_category_question_path(survey_id: survey.id, category_id: category.id, id: question.id), data: { turbo_stream: true }, class: button_class('secondary') if allowed_to?(:edit?, question) %>
           <%= link_to MaterialIconComponent.new(icon: :delete, title: 'Delete Question').render, admin_survey_category_question_path(survey_id: survey.id, category_id: category.id, id: question.id), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this question?" }, class: button_class('danger') if allowed_to?(:destroy?, question) %>
         </div>

--- a/app/views/admin/survey/score_range_steps/_list.html.erb
+++ b/app/views/admin/survey/score_range_steps/_list.html.erb
@@ -1,10 +1,10 @@
 <div id="js_survey_score_range_steps_list" class="mt-3">
   <% survey.score_range_steps.each do |step| %>
     <div class="d-flex justify-content-between border-bottom py-2">
-      <div><strong><%= step.calculated_range_min_points %>-<%= step.calculated_range_max_points %>: <%= step.name %></strong> - <%= step.description %></div>
-      <div>
-        <%= link_to 'Edit', edit_admin_survey_score_range_step_path(survey, step), data: { turbo_stream: true }, class: button_class('primary') if allowed_to?(:edit?, step) %>
-        <%= link_to "Delete", admin_survey_score_range_step_path(survey, step), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this score range step?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, step) %>
+      <div class="me-3"><strong><%= step.calculated_range_min_points %>-<%= step.calculated_range_max_points %>: <%= step.name %></strong> - <%= step.description %></div>
+      <div class="flex-shrink-0">
+        <%= link_to MaterialIconComponent.new(icon: :edit, title: 'Edit Step').render, edit_admin_survey_score_range_step_path(survey, step), data: { turbo_stream: true }, class: button_class('secondary') if allowed_to?(:edit?, step) %>
+        <%= link_to MaterialIconComponent.new(icon: :delete, title: 'Delete Step').render, admin_survey_score_range_step_path(survey, step), data: { turbo_method: :delete, turbo_stream: true, turbo_confirm: "Are you sure you want to delete this score range step?" }, class: button_class('danger') if allowed_to?(:destroy?, step) %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/surveys/_action_buttons.html.erb
+++ b/app/views/admin/surveys/_action_buttons.html.erb
@@ -1,6 +1,26 @@
-<%= link_to "Edit", edit_admin_survey_path(survey), class: "btn btn-sm btn-primary" if allowed_to?(:edit?, survey) %>
-<%= button_to "Publish", publish_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary display-block" if allowed_to?(:publish?, survey) %>
-<%= button_to "Archive", archive_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:archive?, survey) %>
-<%= button_to "Make Public", make_public_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:make_public?, survey) %>
-<%= button_to "Make Private", make_private_admin_survey_path(survey), method: :post, class: "btn btn-sm btn-primary" if allowed_to?(:make_private?, survey) %>
-<%= button_to "Delete", admin_survey_path(survey), method: :delete, data: { turbo_confirm: "Are you sure you want to delete this survey?" }, class: "btn btn-sm btn-danger" if allowed_to?(:destroy?, survey) %>
+<% if allowed_to?(:publish?, survey) %>
+  <%= button_to publish_admin_survey_path(survey), method: :post, data: { turbo_confirm: "Are you sure? Once you publish, you can no longer edit a survey. You may only archive a survey if you wish to remove it." }, class: button_class("success display-block") do %>
+    <%= MaterialIconComponent.new(icon: :publish, title: 'Publish Survey').render %> Publish
+  <% end %>
+<% end %>
+
+<% if allowed_to?(:archive?, survey) %>
+  <%= button_to archive_admin_survey_path(survey), method: :post, class: button_class("secondary") do %>
+    <%= MaterialIconComponent.new(icon: :archive, title: 'Archive Survey').render %> Archive
+  <% end %>
+<% end %>
+
+<%= button_to "Make Public", make_public_admin_survey_path(survey), method: :post, class: button_class("secondary"), data: { turbo_confirm: "Are you sure? Once you make a survey public all users will be able to view and respond to it. Survey responses will only ever be visible to the user who submitted them. You may toggle this setting at any time." } if allowed_to?(:make_public?, survey) %>
+<%= button_to "Make Private", make_private_admin_survey_path(survey), method: :post, class: button_class("secondary"), data: { turbo_confirm: "Making a survey private means that only you will be able to see it. You may toggle this setting at any time." } if allowed_to?(:make_private?, survey) %>
+
+<% if allowed_to?(:edit?, survey) %>
+  <%= link_to edit_admin_survey_path(survey), class: button_class("secondary") do %>
+    <%= MaterialIconComponent.new(icon: :edit, title: 'Edit Survey').render %> Edit
+  <% end %>
+<% end %>
+
+<% if allowed_to?(:destroy?, survey) %>
+  <%= button_to admin_survey_path(survey), method: :delete, data: { turbo_confirm: "Are you sure you want to delete this survey?" }, class: button_class("danger") do %>
+    <%= MaterialIconComponent.new(icon: :delete, title: 'Delete Survey').render %> Delete
+  <% end %>
+<% end %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -1,12 +1,13 @@
 <% content_for(:title, @survey.name) %>
 
-<div class="d-flex justify-content-between">
-  <h1><%= @survey.name.titleize %> <span class="fs-6 text">(<%= @survey.status %>)</span></h1>
+<div class="d-flex justify-content-between mb-3">
+  <%= link_to '← Back to Surveys', admin_surveys_path, class: button_class('secondary') %>
   <div class="d-flex justify-content-end align-items-start gap-1">
-    <%= link_to '← Back to Surveys', admin_surveys_path, class: button_class('secondary') %>
     <%= render partial: "action_buttons", locals: {survey: @survey} %>
   </div>
 </div>
+
+<h1><%= @survey.name.titleize %> <span class="fs-6 text">(<%= @survey.status %>)</span></h1>
 <p><%= @survey.description %></p> 
 
 <div class="row mb-3">


### PR DESCRIPTION
## Related Issues & PRs
Closes #1188

## Problems Solved
- reduces visual noise by...
  - converting buttons to outline icon-only for each item row
  - using fewer colors for buttons
- handles design bug where row-end icons stack on each other when the line copy is long or on mobile
- moves the main survey buttons to a row above the title so there is no interference for longer titles

## Screenshots
Before
<img width="1154" height="756" alt="Screenshot 2026-05-07 at 11 34 06 AM" src="https://github.com/user-attachments/assets/5b008b77-4c8e-4655-a201-8d6fe7102704" />

After
<img width="1151" height="695" alt="Screenshot 2026-05-07 at 11 33 05 AM" src="https://github.com/user-attachments/assets/e73d9a64-f006-402f-839a-d617cc56e7dc" />

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [ ] I have tested this work in the console
- [ ] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
