### PR TITLE
Trigger step points recalculation upon CRUD

### DIFF
--- a/app/controllers/admin/survey/answer_options_controller.rb
+++ b/app/controllers/admin/survey/answer_options_controller.rb
@@ -3,7 +3,7 @@ class Admin::Survey::AnswerOptionsController < AdminController
   before_action :set_survey, only: [:new, :create, :edit, :update, :destroy]
 
   def new
-    @answer_option = @survey.answer_options.new
+    @answer_option = @survey.answer_options.new(value: calculated_answer_option_value)
     authorize! @answer_option
 
     respond_to do |format|
@@ -63,6 +63,10 @@ class Admin::Survey::AnswerOptionsController < AdminController
   end
 
   private
+
+  def calculated_answer_option_value
+    @survey.answer_options.any? ? (@survey.answer_options.maximum(:value).to_i + 1) : 0
+  end
 
   def set_survey
     @survey = Survey.find(params[:survey_id])

--- a/app/controllers/admin/survey/answer_options_controller.rb
+++ b/app/controllers/admin/survey/answer_options_controller.rb
@@ -17,6 +17,7 @@ class Admin::Survey::AnswerOptionsController < AdminController
 
     respond_to do |format|
       if @answer_option.save
+        @survey.calculate_score_range_steps_points!
         format.turbo_stream
         format.html { redirect_to admin_survey_path(@survey), notice: "Answer option was successfully created." }
       else
@@ -39,6 +40,7 @@ class Admin::Survey::AnswerOptionsController < AdminController
 
     respond_to do |format|
       if @answer_option.update(answer_option_params)
+        @survey.calculate_score_range_steps_points!
         format.turbo_stream
         format.html { redirect_to admin_survey_path(@survey), notice: "Answer option was successfully updated." }
       else
@@ -53,6 +55,7 @@ class Admin::Survey::AnswerOptionsController < AdminController
 
     respond_to do |format|
       if @answer_option.destroy
+        @survey.calculate_score_range_steps_points!
         format.turbo_stream
         format.html { redirect_to admin_survey_path(@survey), notice: "#{@answer_option.name} was successfully destroyed." }
       end

--- a/app/controllers/admin/survey/score_range_steps_controller.rb
+++ b/app/controllers/admin/survey/score_range_steps_controller.rb
@@ -17,6 +17,7 @@ class Admin::Survey::ScoreRangeStepsController < AdminController
 
     respond_to do |format|
       if @score_range_step.save
+        @survey.calculate_score_range_steps_points!
         format.turbo_stream
         format.html { redirect_to admin_survey_path(@survey), notice: "Score range step was successfully created." }
       else
@@ -39,6 +40,7 @@ class Admin::Survey::ScoreRangeStepsController < AdminController
 
     respond_to do |format|
       if @score_range_step.update(score_range_step_params)
+        @survey.calculate_score_range_steps_points!
         format.turbo_stream
         format.html { redirect_to admin_survey_path(@survey), notice: "Score range step was successfully updated." }
       else
@@ -53,6 +55,7 @@ class Admin::Survey::ScoreRangeStepsController < AdminController
 
     respond_to do |format|
       if @score_range_step.destroy
+        @survey.calculate_score_range_steps_points!
         format.turbo_stream
         format.html { redirect_to admin_survey_path(@survey), notice: "#{@score_range_step.name} was successfully destroyed." }
       end

--- a/app/helpers/surveys_helper.rb
+++ b/app/helpers/surveys_helper.rb
@@ -2,6 +2,8 @@
 
 module SurveysHelper
   def display_score_range_steps?(survey)
-    allowed_to?(:edit?, survey) && survey.questions.any?
+    allowed_to?(:edit?, survey) &&
+      survey.questions.any? &&
+      survey.answer_options.maximum(:value) > 0
   end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -63,10 +63,8 @@ class Survey < ApplicationRecord
     @max_score ||= questions.size * calculated_question_max_points
   end
 
-  # TODO: determine when this method should be called and implement that.
-  # This should likely be called after any changes to questions, answer options, or score
-  # range steps, and should likely also be called as part of a publish action for the survey.
   def calculate_score_range_steps_points!
+    reload # required to ensure we have the latest associations
     score_range_steps.update_all(calculated_range_min_points: nil, calculated_range_max_points: nil)
     num_steps = score_range_steps.ordered.size
 
@@ -84,6 +82,13 @@ class Survey < ApplicationRecord
       step.update!(calculated_range_min_points: current_min, calculated_range_max_points: current_min + step_size - 1)
       current_min += step_size
     end
+  end
+
+  def calculate_min_and_max_points!
+    reload # required to ensure we have the latest associations
+    min_points = answer_options.minimum(:value)
+    max_points = answer_options.maximum(:value)
+    update!(calculated_question_min_points: min_points, calculated_question_max_points: max_points)
   end
 
   # TODO: determine what is required for a survey to be publishable and implement this method.

--- a/app/models/survey/answer_option.rb
+++ b/app/models/survey/answer_option.rb
@@ -41,16 +41,11 @@ class Survey::AnswerOption < ApplicationRecord
   scope :ordered, -> { order(value: :asc) }
 
   after_save :update_survey_question_min_and_max_point_values
+  after_destroy :update_survey_question_min_and_max_point_values
 
   private
 
   def update_survey_question_min_and_max_point_values
-    if survey.calculated_question_min_points.nil? || value < survey.calculated_question_min_points
-      survey.update!(calculated_question_min_points: value)
-    end
-
-    if survey.calculated_question_max_points.nil? || value > survey.calculated_question_max_points
-      survey.update!(calculated_question_max_points: value)
-    end
+    survey.calculate_min_and_max_points!
   end
 end

--- a/app/views/admin/survey/answer_options/_form.html.erb
+++ b/app/views/admin/survey/answer_options/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row border-top border-bottom mb-3">
     <div class="col p-2 border-end border-start bg-light">  
-      <%= form_with model: [:admin, answer_option], html: { novalidate: true } do |form| %>
+      <%= form_with model: answer_option, url: url, html: { novalidate: true } do |form| %>
         
         <%= render 'shared/errors', object: answer_option %>
         <%= form.hidden_field :survey_id, value: survey.id %>

--- a/app/views/admin/survey/answer_options/create.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/create.turbo_stream.erb
@@ -3,3 +3,7 @@
 <%= turbo_stream.replace "js_survey_answer_options_list" do %>
   <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
 <% end %>
+
+<%= turbo_stream.replace "js_survey_score_interpretation_section" do %>  
+  <%= render partial: 'admin/surveys/score_interpretation', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/answer_options/destroy.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/destroy.turbo_stream.erb
@@ -3,3 +3,7 @@
 <%= turbo_stream.replace "js_survey_answer_options_list" do %>
   <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
 <% end %>
+
+<%= turbo_stream.replace "js_survey_score_interpretation_section" do %>  
+  <%= render partial: 'admin/surveys/score_interpretation', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/answer_options/edit.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update "js_survey_answer_option_form" do %>
-  <%= render partial: "admin/survey/answer_options/form", locals: {survey: @answer_option.survey, answer_option: @answer_option} %>
+  <%= render partial: "admin/survey/answer_options/form", locals: {survey: @answer_option.survey, answer_option: @answer_option, url: admin_survey_answer_option_path(@answer_option.survey, @answer_option)} %>
 <% end %>

--- a/app/views/admin/survey/answer_options/new.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/new.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update "js_survey_answer_option_form" do %>
-  <%= render partial: "admin/survey/answer_options/form", locals: {survey: @survey, answer_option: @answer_option} %>
+  <%= render partial: "admin/survey/answer_options/form", locals: {survey: @survey, answer_option: @answer_option, url: admin_survey_answer_options_path(@survey)} %>
 <% end %>

--- a/app/views/admin/survey/answer_options/update.turbo_stream.erb
+++ b/app/views/admin/survey/answer_options/update.turbo_stream.erb
@@ -3,3 +3,7 @@
 <%= turbo_stream.replace "js_survey_answer_options_list" do %>
   <%= render partial: 'admin/survey/answer_options/list', locals: {survey: @survey} %>
 <% end %>
+
+<%= turbo_stream.replace "js_survey_score_interpretation_section" do %>  
+  <%= render partial: 'admin/surveys/score_interpretation', locals: {survey: @survey} %>
+<% end %>

--- a/app/views/admin/survey/questions/create.turbo_stream.erb
+++ b/app/views/admin/survey/questions/create.turbo_stream.erb
@@ -4,6 +4,6 @@
   <%= render partial: 'admin/survey/categories/category', locals: {survey: @survey, category: @category} %>
 <% end %>
 
-<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
-  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<%= turbo_stream.replace "js_survey_score_interpretation_section" do %>  
+  <%= render partial: 'admin/surveys/score_interpretation', locals: {survey: @survey} %>
 <% end %>

--- a/app/views/admin/survey/questions/destroy.turbo_stream.erb
+++ b/app/views/admin/survey/questions/destroy.turbo_stream.erb
@@ -4,6 +4,6 @@
   <%= render partial: 'admin/survey/categories/category', locals: {survey: @survey, category: @category} %>
 <% end %>
 
-<%= turbo_stream.replace "js_survey_score_range_steps_list" do %>
-  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
+<%= turbo_stream.replace "js_survey_score_interpretation_section" do %>  
+  <%= render partial: 'admin/surveys/score_interpretation', locals: {survey: @survey} %>
 <% end %>

--- a/app/views/admin/survey/score_range_steps/_form.html.erb
+++ b/app/views/admin/survey/score_range_steps/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row border-top border-bottom mb-3">
     <div class="col p-2 border-end border-start bg-light">  
-      <%= form_with model: [:admin, score_range_step], html: { novalidate: true } do |form| %>
+      <%= form_with model: score_range_step, url: url, html: { novalidate: true } do |form| %>
         
         <%= render 'shared/errors', object: score_range_step %>
         <%= form.hidden_field :survey_id, value: survey.id %>

--- a/app/views/admin/survey/score_range_steps/edit.turbo_stream.erb
+++ b/app/views/admin/survey/score_range_steps/edit.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update "js_survey_score_range_step_form" do %>
-  <%= render partial: "admin/survey/score_range_steps/form", locals: {survey: @survey, score_range_step: @score_range_step} %>
+  <%= render partial: "admin/survey/score_range_steps/form", locals: {survey: @survey, score_range_step: @score_range_step, url: admin_survey_score_range_step_path(@survey, @score_range_step)} %>
 <% end %>

--- a/app/views/admin/survey/score_range_steps/new.turbo_stream.erb
+++ b/app/views/admin/survey/score_range_steps/new.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.update "js_survey_score_range_step_form" do %>
-  <%= render partial: "admin/survey/score_range_steps/form", locals: {survey: @survey, score_range_step: @score_range_step} %>
+  <%= render partial: "admin/survey/score_range_steps/form", locals: {survey: @survey, score_range_step: @score_range_step, url: admin_survey_score_range_steps_path(@survey)} %>
 <% end %>

--- a/app/views/admin/surveys/_score_interpretation.erb
+++ b/app/views/admin/surveys/_score_interpretation.erb
@@ -1,0 +1,12 @@
+<div id="js_survey_score_interpretation_section">
+  <% if display_score_range_steps?(survey) %>
+    <div class="d-flex justify-content-between align-items-start border-top pt-3 mt-5">
+      <h2 class="fs-4 text">Score Interpretation</h2>
+      <%= link_to '+ Add Step', new_admin_survey_score_range_step_path(survey), data: { turbo_stream: true }, class: button_class('primary') if display_score_range_steps?(survey) %>
+    </div>
+    <p>Add score range steps to help interpret the meaning of a score after taking this survey.</p>
+
+    <%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
+    <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: survey} %>
+  <% end %>
+</div>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -31,4 +31,3 @@
 </div>
 
 <%= render partial: 'score_interpretation', locals: {survey: @survey} %>
-

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -30,14 +30,5 @@
   </div>
 </div>
 
-<div class="d-flex justify-content-between align-items-start">
-  <h2 class="fs-4 text">Score Interpretation</h2>
-  <%= link_to '+ Add Step', new_admin_survey_score_range_step_path(@survey), data: { turbo_stream: true }, class: button_class('primary') if display_score_range_steps?(@survey) %>
-</div>
-<% if display_score_range_steps?(@survey) %>
-  <%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
-  <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: @survey} %>
-<% else %>
-  <p class="text">Add questions to the survey to enable score interpretation.</p>
-<% end %>
+<%= render partial: 'score_interpretation', locals: {survey: @survey} %>
 

--- a/spec/helpers/surveys_helper_spec.rb
+++ b/spec/helpers/surveys_helper_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SurveysHelper, type: :helper do
+  describe "#display_score_range_steps?" do
+    let(:survey) { build_stubbed(:survey) }
+
+    before do
+      allow(helper).to receive(:allowed_to?).and_return(true)
+      allow(survey).to receive_message_chain(:questions, :any?).and_return(true)
+      allow(survey).to receive_message_chain(:answer_options, :maximum).and_return(1)
+    end
+
+    context "when all conditions are met" do
+      it "returns true" do
+        expect(helper.display_score_range_steps?(survey)).to be(true)
+      end
+    end
+
+    context "when the user is not authorized to edit the survey" do
+      before { allow(helper).to receive(:allowed_to?).and_return(false) }
+
+      it "returns false" do
+        expect(helper.display_score_range_steps?(survey)).to be(false)
+      end
+    end
+
+    context "when the survey has no questions" do
+      before { allow(survey).to receive_message_chain(:questions, :any?).and_return(false) }
+
+      it "returns false" do
+        expect(helper.display_score_range_steps?(survey)).to be(false)
+      end
+    end
+
+    context "when the maximum answer option value is not greater than 0" do
+      before { allow(survey).to receive_message_chain(:answer_options, :maximum).and_return(0) }
+
+      it "returns false" do
+        expect(helper.display_score_range_steps?(survey)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -89,6 +89,11 @@ RSpec.describe Survey, type: :model do
 
       expect(survey.max_score).to eq(15) # 3 questions * 5 points each
     end
+
+    it "returns nil when calculated_question_max_points has not been set" do
+      survey = create(:survey)
+      expect(survey.max_score).to be_nil
+    end
   end
 
   describe "calculate_score_range_steps_points!" do
@@ -184,6 +189,26 @@ RSpec.describe Survey, type: :model do
         expect(survey.score_range_steps[-1].calculated_range_min_points).to eq(17)
         expect(survey.score_range_steps[-1].calculated_range_max_points).to eq(21)
       end
+    end
+  end
+
+  describe "calculate_min_and_max_points!" do
+    let(:survey) { create(:survey) }
+
+    it "sets calculated_question_min_points from the minimum answer option value" do
+      create(:survey_answer_option, survey: survey, value: 1, name: "Never")
+      create(:survey_answer_option, survey: survey, value: 2, name: "Sometimes")
+      create(:survey_answer_option, survey: survey, value: 3, name: "Always")
+      survey.calculate_min_and_max_points!
+      expect(survey.reload.calculated_question_min_points).to eq(1)
+    end
+
+    it "sets calculated_question_max_points from the maximum answer option value" do
+      create(:survey_answer_option, survey: survey, value: 1, name: "Never")
+      create(:survey_answer_option, survey: survey, value: 2, name: "Sometimes")
+      create(:survey_answer_option, survey: survey, value: 3, name: "Always")
+      survey.calculate_min_and_max_points!
+      expect(survey.reload.calculated_question_max_points).to eq(3)
     end
   end
 end

--- a/spec/requests/admin/survey/answer_options_spec.rb
+++ b/spec/requests/admin/survey/answer_options_spec.rb
@@ -87,6 +87,11 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
 
           expect(response).to redirect_to admin_survey_path(survey)
         end
+
+        it "calls calculate_score_range_steps_points!" do
+          expect_any_instance_of(Survey).to receive(:calculate_score_range_steps_points!)
+          post admin_survey_answer_options_path(survey), params: {survey_answer_option: {name: "Mild", value: 1, survey_id: survey.id}}
+        end
       end
 
       context "with invalid params" do
@@ -113,6 +118,11 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
           expect(answer_option.reload.name).to eq("Updated Name")
           expect(response).to redirect_to admin_survey_path(survey)
         end
+
+        it "calls calculate_score_range_steps_points!" do
+          expect_any_instance_of(Survey).to receive(:calculate_score_range_steps_points!)
+          patch admin_survey_answer_option_path(survey, answer_option), params: {survey_answer_option: {name: "Updated Name"}}
+        end
       end
 
       context "with invalid params" do
@@ -134,6 +144,12 @@ RSpec.describe "Admin::Survey::AnswerOptions", type: :request do
         }.to change(Survey::AnswerOption, :count).by(-1)
 
         expect(response).to redirect_to admin_survey_path(survey)
+      end
+
+      it "calls calculate_score_range_steps_points!" do
+        answer_option_to_delete = create(:survey_answer_option, survey: survey)
+        expect_any_instance_of(Survey).to receive(:calculate_score_range_steps_points!)
+        delete admin_survey_answer_option_path(survey, answer_option_to_delete)
       end
     end
   end

--- a/spec/requests/admin/survey/score_range_steps_spec.rb
+++ b/spec/requests/admin/survey/score_range_steps_spec.rb
@@ -95,6 +95,11 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
 
           expect(response).to redirect_to admin_survey_path(survey)
         end
+
+        it "calls calculate_score_range_steps_points!" do
+          expect_any_instance_of(Survey).to receive(:calculate_score_range_steps_points!)
+          post admin_survey_score_range_steps_path(survey), params: {survey_score_range_step: {name: "Mild", position: 1, survey_id: survey.id}}
+        end
       end
 
       context "with invalid params" do
@@ -121,6 +126,11 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
           expect(score_range_step.reload.name).to eq("Updated Name")
           expect(response).to redirect_to admin_survey_path(survey)
         end
+
+        it "calls calculate_score_range_steps_points!" do
+          expect_any_instance_of(Survey).to receive(:calculate_score_range_steps_points!)
+          patch admin_survey_score_range_step_path(survey, score_range_step), params: {survey_score_range_step: {name: "Updated Name"}}
+        end
       end
 
       context "with invalid params" do
@@ -142,6 +152,12 @@ RSpec.describe "Admin::Survey::ScoreRangeSteps", type: :request do
         }.to change(Survey::ScoreRangeStep, :count).by(-1)
 
         expect(response).to redirect_to admin_survey_path(survey)
+      end
+
+      it "calls calculate_score_range_steps_points!" do
+        step_to_delete = create(:survey_score_range_step, survey: survey)
+        expect_any_instance_of(Survey).to receive(:calculate_score_range_steps_points!)
+        delete admin_survey_score_range_step_path(survey, step_to_delete)
       end
     end
   end


### PR DESCRIPTION
## Related Issues & PRs
Closes #1186
Closes #1187

## Problems Solved
- It runs the calculation for the score range steps min and max points after `create`, `update`, and `destroy` in the `Admin::Survey::ScoreRangeStepsController` and the `Admin::Survey::AnswerOptionsController` because these two objects are required for the calculation and this will keep the score ranges up-to-date and accurate. 
- Though `create` and `destroy` are obvious because if a step is added or removed, it makes sense to recalculate the ranges for the remaining steps, I also chose to recalculate on `update`. I did this as a fallback because there may be a scenario where recalculation should have happened, but was missed. Being able to edit a step to trigger a recalculation feels like a quick fix to the scenario.
- I also added logic to the display helper for the score range steps to include a minimum value for answer options. This will keep the view from looking broken as a user figured out their answer options. 
- In the process of getting these calculations prompted, I discovered routing bugs in both the score_range_steps and answer_options forms that was introduced in #1180. With the new routes structure, the `PATCH` functionality was broken. I was able to resolve this with the same pattern as the `questions` resource y simply passing the appropriate url from the `new` and `edit` views. 

## Things Learned
- reloading relationships was crucial in the `Survey` model in order to get fresh associations for the calculations

## Due Diligence Checks

- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [ ] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
