### PR TITLE
Admin Surveys: add instructions to surveys

### DIFF
--- a/app/controllers/admin/surveys_controller.rb
+++ b/app/controllers/admin/surveys_controller.rb
@@ -81,6 +81,6 @@ class Admin::SurveysController < AdminController
   end
 
   def survey_params
-    params.require(:survey).permit(:name, :description, :status, :available_to_public)
+    params.require(:survey).permit(:name, :description, :instructions, :status, :available_to_public)
   end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -9,6 +9,7 @@
 #  calculated_question_max_points :integer
 #  calculated_question_min_points :integer
 #  description                    :text
+#  instructions                   :text
 #  name                           :string           not null
 #  status                         :integer          default("draft"), not null
 #  created_at                     :datetime         not null

--- a/app/views/admin/surveys/_form.html.erb
+++ b/app/views/admin/surveys/_form.html.erb
@@ -8,6 +8,10 @@
     <%= form.label :description %>
     <%= form.text_area :description, class: 'form-control' %>
   </div>
+  <div class="mb-3">
+    <%= form.label :instructions %>
+    <%= form.text_area :instructions, class: 'form-control' %>
+  </div>
   <% if form.object.persisted? %>
     <%= form.submit class: button_class('primary')  %>
   <% else %>

--- a/app/views/admin/surveys/show.html.erb
+++ b/app/views/admin/surveys/show.html.erb
@@ -8,7 +8,10 @@
 </div>
 
 <h1><%= @survey.name.titleize %> <span class="fs-6 text">(<%= @survey.status %>)</span></h1>
-<p><%= @survey.description %></p> 
+<p class="text-muted fst-italic"><%= @survey.description %></p> 
+
+<h2 class="fs-4 text">Instructions</h2>
+<p class="mb-5"><%= @survey.instructions %></p> 
 
 <div class="row mb-3">
   <div class="col-12 col-md-7">

--- a/db/migrate/20260507195551_add_instructions_to_surveys.rb
+++ b/db/migrate/20260507195551_add_instructions_to_surveys.rb
@@ -1,0 +1,5 @@
+class AddInstructionsToSurveys < ActiveRecord::Migration[8.1]
+  def change
+    add_column :surveys, :instructions, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_153448) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_195551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -261,6 +261,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_24_153448) do
     t.integer "calculated_question_min_points"
     t.datetime "created_at", null: false
     t.text "description"
+    t.text "instructions"
     t.string "name", null: false
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false

--- a/lib/tasks/seed/surveys.rake
+++ b/lib/tasks/seed/surveys.rake
@@ -26,6 +26,7 @@ namespace :db do
         user_id: user.id,
         name: "Depression Checklist",
         description: "A survey to track symptoms of depression over time.",
+        instructions: "Please answer the following questions about your feelings and experiences over the past 4 days.",
         status: :published,
         available_to_public: false
       )

--- a/spec/factories/surveys.rb
+++ b/spec/factories/surveys.rb
@@ -9,6 +9,7 @@
 #  calculated_question_max_points :integer
 #  calculated_question_min_points :integer
 #  description                    :text
+#  instructions                   :text
 #  name                           :string           not null
 #  status                         :integer          default("draft"), not null
 #  created_at                     :datetime         not null
@@ -27,6 +28,7 @@ FactoryBot.define do
   factory :survey do
     sequence(:name) { |n| "survey#{n}" }
     sequence(:description) { |n| "survey#{n} description" }
+    sequence(:instructions) { |n| "survey#{n} instructions" }
     calculated_question_min_points { nil }
     calculated_question_max_points { nil }
     status { :draft }

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -9,6 +9,7 @@
 #  calculated_question_max_points :integer
 #  calculated_question_min_points :integer
 #  description                    :text
+#  instructions                   :text
 #  name                           :string           not null
 #  status                         :integer          default("draft"), not null
 #  created_at                     :datetime         not null


### PR DESCRIPTION
## Related Issues & PRs
Closes #1192

## Problems Solved
- Provides a field for a survey author to add instructions for a survey

## Screenshots
<img width="1172" height="517" alt="Screenshot 2026-05-07 at 4 11 29 PM" src="https://github.com/user-attachments/assets/7f96ab3a-0090-42ec-a750-d6c2c3c5fe7a" />
<img width="1149" height="520" alt="Screenshot 2026-05-07 at 4 11 36 PM" src="https://github.com/user-attachments/assets/c796102a-1edf-4d5d-8ae3-797ee8c618a8" />


## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [x] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
