### PR TITLE
Admin Surveys: make score range value auto-calculation optional

### DIFF
--- a/app/controllers/admin/survey/score_range_steps_controller.rb
+++ b/app/controllers/admin/survey/score_range_steps_controller.rb
@@ -77,6 +77,6 @@ class Admin::Survey::ScoreRangeStepsController < AdminController
   end
 
   def score_range_step_params
-    params.require(:survey_score_range_step).permit(:name, :position, :description, :survey_id)
+    params.require(:survey_score_range_step).permit(:name, :position, :description, :survey_id, :calculated_range_min_points, :calculated_range_max_points)
   end
 end

--- a/app/controllers/admin/surveys_controller.rb
+++ b/app/controllers/admin/surveys_controller.rb
@@ -33,6 +33,7 @@ class Admin::SurveysController < AdminController
     authorize! @survey
 
     if @survey.update(survey_params)
+      @survey.calculate_score_range_steps_points!
       redirect_to admin_survey_path(@survey)
     else
       render :edit
@@ -81,6 +82,6 @@ class Admin::SurveysController < AdminController
   end
 
   def survey_params
-    params.require(:survey).permit(:name, :description, :instructions, :status, :available_to_public)
+    params.require(:survey).permit(:name, :description, :instructions, :status, :available_to_public, :auto_calculate_score_range_steps)
   end
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -4,17 +4,18 @@
 #
 # Table name: surveys
 #
-#  id                             :uuid             not null, primary key
-#  available_to_public            :boolean          default(FALSE), not null
-#  calculated_question_max_points :integer
-#  calculated_question_min_points :integer
-#  description                    :text
-#  instructions                   :text
-#  name                           :string           not null
-#  status                         :integer          default("draft"), not null
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  user_id                        :bigint
+#  id                               :uuid             not null, primary key
+#  auto_calculate_score_range_steps :boolean          default(TRUE), not null
+#  available_to_public              :boolean          default(FALSE), not null
+#  calculated_question_max_points   :integer
+#  calculated_question_min_points   :integer
+#  description                      :text
+#  instructions                     :text
+#  name                             :string           not null
+#  status                           :integer          default("draft"), not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  user_id                          :bigint
 #
 # Indexes
 #
@@ -65,6 +66,8 @@ class Survey < ApplicationRecord
   end
 
   def calculate_score_range_steps_points!
+    return unless auto_calculate_score_range_steps
+
     reload # required to ensure we have the latest associations
     score_range_steps.update_all(calculated_range_min_points: nil, calculated_range_max_points: nil)
     num_steps = score_range_steps.ordered.size

--- a/app/views/admin/survey/score_range_steps/_form.html.erb
+++ b/app/views/admin/survey/score_range_steps/_form.html.erb
@@ -6,27 +6,37 @@
         <%= render 'shared/errors', object: score_range_step %>
         <%= form.hidden_field :survey_id, value: survey.id %>
 
-        <div class="row">
-          <div class="col-3">
-            <div class="mb-3">
-              <%= form.label :position, class: "required" %>
-              <%= form.number_field :position, required: true, class: 'form-control' %>
-            </div>
-          </div>
-          <div class="col-9">
-            <div class="mb-3">
-              <%= form.label :name, class: "required" %>
-              <%= form.text_field :name, required: true, class: 'form-control' %>
-            </div>
-          </div>
+        <div class="mb-3">
+          <%= form.label :position, class: "required" %>
+          <span class="form-text">The order this range should appear in the list of range steps</span>
+          <%= form.number_field :position, required: true, class: 'form-control' %>
         </div>
-        <div class="row">
-          <div class="col-12">
-            <div class="mb-3">
-              <%= form.label :description %>
-              <%= form.text_area :description, class: 'form-control' %>
+
+        <% unless survey.auto_calculate_score_range_steps? %>
+          <div class="row">
+            <div class="col-12 col-md-6">
+              <div class="mb-3">
+                <%= form.label "Range Min Points", class: "required" %>
+                <%= form.number_field :calculated_range_min_points, required: true, class: 'form-control' %>
+              </div>
+            </div>
+            <div class="col-12 col-md-6">
+              <div class="mb-3">
+                <%= form.label "Range Max Points", class: "required" %>
+                <%= form.number_field :calculated_range_max_points, required: true, class: 'form-control' %>
+              </div>
             </div>
           </div>
+        <% end %>
+
+        <div class="mb-3">
+          <%= form.label :name, class: "required" %>
+          <%= form.text_field :name, required: true, class: 'form-control' %>
+        </div>
+
+        <div class="mb-3">
+          <%= form.label :description %>
+          <%= form.text_area :description, class: 'form-control' %>
         </div>
 
         <div class="actions d-flex justify-content-end align-items-start gap-2">

--- a/app/views/admin/surveys/_form.html.erb
+++ b/app/views/admin/surveys/_form.html.erb
@@ -4,14 +4,23 @@
     <%= form.label :name, class: 'required' %>
     <%= form.text_field :name, class: 'form-control' %>
   </div>
+
   <div class="mb-3">
     <%= form.label :description %>
     <%= form.text_area :description, class: 'form-control' %>
   </div>
+
   <div class="mb-3">
     <%= form.label :instructions %>
     <%= form.text_area :instructions, class: 'form-control' %>
   </div>
+
+  <div class='form-check mb-3 px-4'>
+    <%= form.check_box :auto_calculate_score_range_steps, class: 'form-check-input' %>
+    <%= form.label 'Auto Calculate Score Range Steps?', class: 'form-check-label' %>
+    <p class="form-text">Checking this box will automatically calculate the min and max points for each score range step based on the answer options associated with the survey questions. This is recommended, but you can uncheck if you want to manually set min and max points for each score range step.</p>
+  </div>
+
   <% if form.object.persisted? %>
     <%= form.submit class: button_class('primary')  %>
   <% else %>

--- a/app/views/admin/surveys/_score_interpretation.erb
+++ b/app/views/admin/surveys/_score_interpretation.erb
@@ -4,7 +4,12 @@
       <h2 class="fs-4 text">Score Interpretation</h2>
       <%= link_to '+ Add Step', new_admin_survey_score_range_step_path(survey), data: { turbo_stream: true }, class: button_class('primary') if display_score_range_steps?(survey) %>
     </div>
-    <p>Add score range steps to help interpret the meaning of a score after taking this survey.</p>
+    <p>
+      Add score range steps to help interpret the meaning of a score after taking this survey.
+      <% if survey.auto_calculate_score_range_steps %>
+        The range min and max values will be automatically calculated based on the number of steps you add and the maximum possible score for this survey.
+      <% end %>
+    </p>
 
     <%= tag.div id: "js_survey_score_range_step_form", data: {controller: "clearable" } %>
     <%= render partial: 'admin/survey/score_range_steps/list', locals: {survey: survey} %>

--- a/db/migrate/20260507202008_add_auto_calculate_score_range_steps_to_surveys.rb
+++ b/db/migrate/20260507202008_add_auto_calculate_score_range_steps_to_surveys.rb
@@ -1,0 +1,5 @@
+class AddAutoCalculateScoreRangeStepsToSurveys < ActiveRecord::Migration[8.1]
+  def change
+    add_column :surveys, :auto_calculate_score_range_steps, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_195551) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_202008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -256,6 +256,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_195551) do
   end
 
   create_table "surveys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.boolean "auto_calculate_score_range_steps", default: true, null: false
     t.boolean "available_to_public", default: false, null: false
     t.integer "calculated_question_max_points"
     t.integer "calculated_question_min_points"

--- a/lib/tasks/seed/surveys.rake
+++ b/lib/tasks/seed/surveys.rake
@@ -28,7 +28,8 @@ namespace :db do
         description: "A survey to track symptoms of depression over time.",
         instructions: "Please answer the following questions about your feelings and experiences over the past 4 days.",
         status: :published,
-        available_to_public: false
+        available_to_public: false,
+        auto_calculate_score_range_steps: true
       )
 
       # Category & Questions for Thoughts

--- a/spec/factories/surveys.rb
+++ b/spec/factories/surveys.rb
@@ -4,17 +4,18 @@
 #
 # Table name: surveys
 #
-#  id                             :uuid             not null, primary key
-#  available_to_public            :boolean          default(FALSE), not null
-#  calculated_question_max_points :integer
-#  calculated_question_min_points :integer
-#  description                    :text
-#  instructions                   :text
-#  name                           :string           not null
-#  status                         :integer          default("draft"), not null
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  user_id                        :bigint
+#  id                               :uuid             not null, primary key
+#  auto_calculate_score_range_steps :boolean          default(TRUE), not null
+#  available_to_public              :boolean          default(FALSE), not null
+#  calculated_question_max_points   :integer
+#  calculated_question_min_points   :integer
+#  description                      :text
+#  instructions                     :text
+#  name                             :string           not null
+#  status                           :integer          default("draft"), not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  user_id                          :bigint
 #
 # Indexes
 #
@@ -33,5 +34,6 @@ FactoryBot.define do
     calculated_question_max_points { nil }
     status { :draft }
     available_to_public { false }
+    auto_calculate_score_range_steps { true }
   end
 end

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -4,17 +4,18 @@
 #
 # Table name: surveys
 #
-#  id                             :uuid             not null, primary key
-#  available_to_public            :boolean          default(FALSE), not null
-#  calculated_question_max_points :integer
-#  calculated_question_min_points :integer
-#  description                    :text
-#  instructions                   :text
-#  name                           :string           not null
-#  status                         :integer          default("draft"), not null
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  user_id                        :bigint
+#  id                               :uuid             not null, primary key
+#  auto_calculate_score_range_steps :boolean          default(TRUE), not null
+#  available_to_public              :boolean          default(FALSE), not null
+#  calculated_question_max_points   :integer
+#  calculated_question_min_points   :integer
+#  description                      :text
+#  instructions                     :text
+#  name                             :string           not null
+#  status                           :integer          default("draft"), not null
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  user_id                          :bigint
 #
 # Indexes
 #
@@ -100,6 +101,19 @@ RSpec.describe Survey, type: :model do
   describe "calculate_score_range_steps_points!" do
     let(:survey) { create(:survey) }
     let(:survey_category) { create(:survey_category, survey: survey) }
+
+    context "when auto_calculate_score_range_steps is false" do
+      it "returns without modifying score range steps" do
+        survey = create(:survey, auto_calculate_score_range_steps: false)
+        step = create(:survey_score_range_step, survey: survey)
+        step.update_columns(calculated_range_min_points: 5, calculated_range_max_points: 10)
+
+        survey.calculate_score_range_steps_points!
+
+        expect(step.reload.calculated_range_min_points).to eq(5)
+        expect(step.reload.calculated_range_max_points).to eq(10)
+      end
+    end
 
     it "assigns min and max points to each of the survey's score_range_steps" do
       5.times { |v| create(:survey_answer_option, survey: survey, value: v, name: "Option #{v}") } # Creates values 0-4
@@ -189,6 +203,12 @@ RSpec.describe Survey, type: :model do
 
         expect(survey.score_range_steps[-1].calculated_range_min_points).to eq(17)
         expect(survey.score_range_steps[-1].calculated_range_max_points).to eq(21)
+      end
+    end
+
+    context "when the auto_calculate_score_range_steps is set to false" do
+      it "returns nil" do
+        # TODO
       end
     end
   end

--- a/spec/requests/admin/surveys_spec.rb
+++ b/spec/requests/admin/surveys_spec.rb
@@ -237,26 +237,31 @@ RSpec.describe "Admin::Surveys", type: :request do
     #   end
     # end
 
-    # describe "PATCH /admin/surveys/:id" do
-    #   context "with valid params" do
-    #     it "updates the survey and redirects to show" do
-    #       patch admin_survey_path(survey), params: {survey: {name: "Updated Name"}}
+    describe "PATCH /admin/surveys/:id" do
+      context "with valid params" do
+        it "updates the survey and redirects to show" do
+          patch admin_survey_path(survey), params: {survey: {name: "Updated Name"}}
 
-    #       expect(survey.reload.name).to eq("Updated Name")
-    #       expect(response).to redirect_to admin_survey_path(survey)
-    #     end
-    #   end
+          expect(survey.reload.name).to eq("Updated Name")
+          expect(response).to redirect_to admin_survey_path(survey)
+        end
 
-    #   context "with invalid params" do
-    #     it "does not update the survey and re-renders edit" do
-    #       original_name = survey.name
-    #       patch admin_survey_path(survey), params: {survey: {name: ""}}
+        it "calls calculate_score_range_steps_points!" do
+          expect_any_instance_of(Survey).to receive(:calculate_score_range_steps_points!)
+          patch admin_survey_path(survey), params: {survey: {name: "Updated Name"}}
+        end
+      end
 
-    #       expect(survey.reload.name).to eq(original_name)
-    #       expect(response).to render_template(:edit)
-    #     end
-    #   end
-    # end
+      context "with invalid params" do
+        it "does not update the survey and re-renders edit" do
+          original_name = survey.name
+          patch admin_survey_path(survey), params: {survey: {name: ""}}
+
+          expect(survey.reload.name).to eq(original_name)
+          expect(response).to render_template(:edit)
+        end
+      end
+    end
 
     # describe "DELETE /admin/surveys/:id" do
     #   it "destroys the survey and redirects to index" do


### PR DESCRIPTION
## Related Issues & PRs
Closes #1193

## Problems Solved
- Some surveys don't have perfectly even divisions between score range steps. 
- This PR allows a user to decide if they want the auto-calculate feature to be turned on/off for a given survey.
- With the feature turned off, the user has to manually calculate the start and end for each range.
- With the feature turned on, the score range step start and end (min and max) values are calculated automatically when any of these assets is modified: questions, answer options, score range steps, and survey
- If the feature was turned off and the user turns it on, the survey will recalculate existing ranges.

## Screenshots
The new checkbox added to the survey form
<img width="1144" height="557" alt="Screenshot 2026-05-07 at 5 04 47 PM" src="https://github.com/user-attachments/assets/ca3bbd67-1315-43ad-a105-7a43b3903a24" />

The new fields in the score range steps form when the auto-calculate feature is turned on
<img width="1106" height="538" alt="Screenshot 2026-05-07 at 5 05 05 PM" src="https://github.com/user-attachments/assets/4565a0eb-6684-45e9-a12d-694871346926" />

The fields are not included in the score range steps form when the auto-calculate feature is turned off
<img width="1099" height="481" alt="Screenshot 2026-05-07 at 5 18 15 PM" src="https://github.com/user-attachments/assets/9809867a-9726-4307-bc7a-3556a1e8f997" />


## Due Diligence Checks

- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [ ] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
