### PR TITLE
Use rspec instead of mini test in CI

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -40,7 +40,7 @@ jobs:
 
       # Add or replace test runners here
       - name: Run tests
-        run: bin/rails test
+        run: bundle exec rspec
 
   check_seeds:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problems Solved
- During the rails upgrade, I updated the CI file. In the process, I accidentally switched the suite over to minitest instead of rspec. Bummer.
- This PR switches back to rspec.
- Unfortunately, there are some failing tests on code that is already merged. Fortunately, none of that code is really in-use at the moment.
- I am merging this PR wth failing tests because of aforementioned reasons.

## Things Learned
- Rails upgrade fatigue is real.

## Due Diligence Checks
- [ ] If this work contains migrations, I have updated factories and seeds accordingly
- [ ] I can confirm there is spec coverage for this work
- [ ] I have tested this work in the browser
- [ ] I have tested this work in the console
- [ ] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
