### PR TITLE
Survey Feature: adjust styles on responses index

### DIFF
--- a/app/controllers/survey/responses_controller.rb
+++ b/app/controllers/survey/responses_controller.rb
@@ -7,7 +7,8 @@ class Survey::ResponsesController < ApplicationController
   def index
     authorize! Survey::Response, to: :index?
 
-    @survey_responses = current_user.survey_responses.where(survey: @survey).order(occurred_at: :desc)
+    response_collection = current_user.survey_responses.where(survey: @survey).order(occurred_at: :desc)
+    @survey_responses = Survey::ResponseDecorator.decorate_collection(response_collection)
   end
 
   def new

--- a/app/views/survey/responses/index.html.erb
+++ b/app/views/survey/responses/index.html.erb
@@ -14,18 +14,23 @@
 
 <div class="container w-100 overflow-x-scroll">
   <div class="row fw-bolder border-bottom border-top mb-0 text-bg-light">
-    <div class="col-4 py-1 px-2">Date Taken</div>
-    <div class="col-4 py-1 px-2">Score</div>
-    <div class="col-4 py-1 px-2">Change from Previous</div>
+    <div class="col-3 py-1 px-2">Date Taken</div>
+    <div class="col-3 py-1 px-2">Score</div>
+    <div class="col-4 py-1 px-2">Note</div>
+    <div class="col-2 py-1 px-2">Change from Previous</div>
   </div>
   
   <% @survey_responses.each do |response| %>
     <div class="row border-bottom mb-0">
-      <div class="col-4 py-1 px-2">
+      <div class="col-3 py-1 px-2">
         <p><%= format_datetime(response.occurred_at) %></p>
       </div>
-      <div class="col-4 py-1 px-2"><%= response.total_score %>/<%= response.survey.max_score %> <%= response.score_range_step.name %></div>
-      <div class="col-4 py-1 px-2"><%= (difference_from_previous_response_score(response)) %></div>
+      <div class="col-3 py-1 px-2">
+        <span class="fs-2 fw-bold"><%= response.total_score %></span>/<%= response.survey.max_score %>
+        <span class="text-muted fst-italic"><%= response.score_name %></span>
+      </div>
+      <div class="col-4 py-1 px-2"><%= response.notes %></div>
+      <div class="col-2 py-1 px-2"><%= (response.difference_from_previous_response) %></div>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
## Problems Solved
- makes the score easier to read
- adds the user note for context
- uses decorator smiley faces to better understand +/- changes from week to week

## Screenshots
before
<img width="1134" height="552" alt="Screenshot 2026-05-12 at 10 33 53 AM" src="https://github.com/user-attachments/assets/9079cdf4-cf07-4a66-b915-ba0170fd406e" />

after
<img width="1135" height="664" alt="Screenshot 2026-05-12 at 10 31 55 AM" src="https://github.com/user-attachments/assets/c602cfad-2867-416a-bf21-a083ccff6e7d" />


## Things Learned
- i forgot to use my decorator before. lol.

## Due Diligence Checks
- [x] If this work contains migrations, I have updated factories and seeds accordingly
- [x] I can confirm there is spec coverage for this work
- [x] I have tested this work in the browser
- [ ] I have tested this work in the console
- [x] I have reviewed this PR
- [ ] I have deployed the feature branch to production and browser tested it successfully
