### PR TITLE
Increment cache  in CI workflow

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -34,6 +34,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
       # Add or replace database setup steps here
       - name: Set up database schema
         run: bin/rails db:schema:load


### PR DESCRIPTION
## Problems Solved
- Bundler 4 has strict Gemfile.lock requirements
- This change should allow bundler to update the Gemfile.lock file

