### PR TITLE
Add cache version to all CI workflows

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -66,6 +66,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
       # Add or replace database setup steps here
       - name: Set up database schema
         run: bin/rails db:schema:load
@@ -81,6 +82,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          cache-version: 1 # Increment this to clear cache if needed
       - name: Standard RB
         run: bundle exec standardrb
   #     #Add or replace any other lints here


### PR DESCRIPTION
## Related Issues & PRs
Continues work from #1215 

## Problems Solved
* Bundler 4 has strict Gemfile.lock requirements
* This change should allow bundler to update the Gemfile.lock file
